### PR TITLE
Pause playback when single mode is toggled.

### DIFF
--- a/src/ashuffle.c
+++ b/src/ashuffle.c
@@ -165,6 +165,10 @@ int try_enqueue(struct mpd_connection * mpd,
          * is zero-indexed, the length will be the position of the song we
          * just added. Play that song */
         mpd_run_play_pos(mpd, mpd_status_get_queue_length(status));
+        /* Immediately pause playback if mpd single mode is on */
+        if (mpd_status_get_single(status)) {
+            mpd_run_pause(mpd, true);
+        }
     }
 
     /* free the status we retrieved */


### PR DESCRIPTION
MPD has a feature called _single mode_, which prevents MPD from progressing to the next song when the current song ends playback.

However, due to the design of ashuffle, where it queues a new track after playback ends and resumes playback, it bypasses the single mode setting and results in unexpected behavior to the end-user.

This patch makes ashuffle check if single mode is toggled and pauses playback right after resuming it. This way it interferes with the rest of the code minimally and still leads to expected behavior to the user, as in, playback pauses after the previous track finishes.