### PR TITLE
build songs: print a helpful message if mpd output buffer is likely too small

### DIFF
--- a/src/ashuffle.c
+++ b/src/ashuffle.c
@@ -132,7 +132,16 @@ int build_songs_mpd(struct mpd_connection * mpd,
 
     /* parse out the pairs */
     struct mpd_song * song = mpd_recv_song(mpd);
-    mpd_perror_if_error(mpd);
+    const enum mpd_error err = mpd_connection_get_error(mpd);
+    if (err == MPD_ERROR_CLOSED) {
+        fprintf(stderr,
+                "mpd server closed the connection while getting the list of all songs.\n"
+                "If mpd logs error on \"Output buffer is full\", consider setting\n"
+                "max_output_buffer_size to a higher value (e.g. 32768).\n");
+	exit(1);
+    } else if (err != MPD_ERROR_SUCCESS) {
+        mpd_perror(mpd);
+    }
     while (song) {
         /* if this song is allowed, add it to the list */
         if (ruleset_accepts_song(ruleset, song)) {


### PR DESCRIPTION
First, thanks for this! Simple, works - it's great, how all softwares should be :)


Most people using ashuffle will likely have a huge library, so the default mpd max_output_buffer_size is likely not enough.
Let's save people running into issues like #9 some time.

Happy to adjust wording/style if required (or drop this and commit it yourself, it's trivial; almost just commented on the original issue but I wasn't sure which function failed with what error and checking is just as much work as making a commit)

(Also, if we're worried about ram usage e.g. #16 then I wonder if there's a better way to get the list a chunk at a time, but that's something else entierly)