### PR TITLE
Integration tests discover latest MPD/mpdclient version

### DIFF
--- a/t/docker/Dockerfile.ubuntu
+++ b/t/docker/Dockerfile.ubuntu
@@ -20,22 +20,21 @@ RUN apt-get update -y && \
 
 # Install Go
 
+COPY /t/docker/scripts/* /opt/helpers/
+
 ENV GO_VERSION 1.13
-COPY /t/docker/scripts/install_go.sh /opt/helpers/
 RUN /opt/helpers/install_go.sh ${GO_VERSION}
 
 # Install libmpdclient
 
 ARG LIBMPDCLIENT_VERSION
 ENV LIBMPDCLIENT_VERSION ${LIBMPDCLIENT_VERSION:-latest}
-COPY /t/docker/scripts/install_libmpdclient.sh /opt/helpers/
 RUN /opt/helpers/install_libmpdclient.sh ${LIBMPDCLIENT_VERSION}
 
 # Install MPD
 
 ARG MPD_VERSION
 ENV MPD_VERSION ${MPD_VERSION:-latest}
-COPY /t/docker/scripts/install_mpd.sh /opt/helpers/
 COPY /t/docker/patches/ /patches/
 RUN /opt/helpers/install_mpd.sh ${MPD_VERSION}
 

--- a/t/docker/scripts/common.sh
+++ b/t/docker/scripts/common.sh
@@ -1,0 +1,29 @@
+diag() {
+    echo $@ >&2
+}
+
+die() {
+    echo $@ >&2
+    exit 1
+}
+
+latest_version() {
+    stage="$(mktemp -d)"
+    test -d "${stage}" || die "${stage} is not a valid directory"
+
+    opwd="${PWD}"
+    cd "${stage}"
+
+    URL="$1"
+    # Pattern to match version-like strings.
+    VMATCH='v\d+\.\d+(\.\d+)?'
+
+    git init 1>/dev/null 2>/dev/null || die "couldn't init git repo"
+    git fetch --tags --depth=1 "${URL}" 2>/dev/null || die "couldn't fetch tags"
+    git tag | grep -P "${VMATCH}" | sed -E 's/^[^0-9]*//' | sort -V --reverse | head -n1
+    exitcode="$?"
+
+    cd "${opwd}"
+    rm -rf "${stage}"
+    exit "${exitcode}"
+}

--- a/t/docker/scripts/install_libmpdclient.sh
+++ b/t/docker/scripts/install_libmpdclient.sh
@@ -2,26 +2,20 @@
 
 set -e
 
+SRC="$( dirname $(readlink -f "$0") )"
+. "$SRC/common.sh"
+
+MAKE_PARALLEL_JOBS=16
+
 PREFIX=/usr
 ROOT="/opt/libmpdclient"
-LATEST_VERSION=2.16
-
-diag() {
-    echo $@ >&2
-}
-
-die() {
-    echo $@ >&2
-    exit 1
-}
+GIT_URL="https://github.com/MusicPlayerDaemon/libmpdclient.git"
 
 do_meson() {
     meson . build --prefix="${PREFIX}" && \
     ninja -C build && \
     ninja -C build install
 }
-
-MAKE_PARALLEL_JOBS=16
 
 do_legacy() {
     errlog="$(tempfile)"
@@ -47,8 +41,9 @@ do_legacy() {
 
 VERSION="$1"
 if test "${VERSION}" = "latest"; then
-    diag "VERSION=latest, using VERSION=${LATEST_VERSION}"
-    VERSION="${LATEST_VERSION}"
+    latest_version="$(latest_version "${GIT_URL}")"
+    diag "VERSION=latest, using VERSION=${latest_version}"
+    VERSION="${latest_version}"
 fi
 
 MAJOR="$(echo "${VERSION}" | cut -d. -f1)"

--- a/t/docker/scripts/install_mpd.sh
+++ b/t/docker/scripts/install_mpd.sh
@@ -2,19 +2,15 @@
 
 set -e
 
+SRC="$( dirname $(readlink -f "$0") )"
+. "$SRC/common.sh"
+
+MAKE_PARALLEL_JOBS=16
+
 PATCH_DIR=/patches
 PREFIX=/usr
 ROOT=/opt/mpd
-LATEST_VERSION="0.21.14"
-
-diag() {
-    echo $@ >&2
-}
-
-die() {
-    echo $@ >&2
-    exit 1
-}
+GIT_URL="https://github.com/MusicPlayerDaemon/MPD.git"
 
 apply_patches() {
     patch_major="$1"
@@ -31,8 +27,6 @@ do_meson() {
     ninja -C build/release && \
     ninja -C build/release install
 }
-
-MAKE_PARALLEL_JOBS=16
 
 do_legacy() {
     errlog="$(tempfile)"
@@ -56,8 +50,9 @@ do_legacy() {
 
 VERSION="$1"
 if test "${VERSION}" = "latest"; then
-    diag "VERSION=latest, using VERSION=${LATEST_VERSION}"
-    VERSION="${LATEST_VERSION}"
+    latest_version="$(latest_version "${GIT_URL}")"
+    diag "VERSION=latest, using VERSION=${latest_version}"
+    VERSION="${latest_version}"
 fi
 
 MAJOR="$(echo "${VERSION}" | cut -d. -f-2)"


### PR DESCRIPTION
Previously, when the MPD or libmpdclient version was set to "latest",
the build scripts would just use a hard-coded "latest" value for the
dependency. With this change, the build scripts will actually pull down
the MPD/libmpdclient repos and parse tag versions to try and discover
the latest version automatically.