### PR TITLE
Remove dependency on Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-scripts/cross/gcc-arm.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/scripts/cross/README.md
+++ b/scripts/cross/README.md
@@ -1,8 +1,0 @@
-This directory contains an AArch64 toolchain used to cross compile ashuffle
-for aarch64. It is released [officially by ARM](
-https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads).
-
-This file is managed using Git LFS, hosted on github.com. Learn more about
-Git LFS at: https://git-lfs.github.com
-
-**Current Version:** 9.2-2019.12

--- a/scripts/cross/gcc-arm.tar.xz
+++ b/scripts/cross/gcc-arm.tar.xz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8dfe681531f0bd04fb9c53cf3c0a3368c616aa85d48938eebe2b516376e06a66
-size 282132940

--- a/tools/meta/fetch/fetch.go
+++ b/tools/meta/fetch/fetch.go
@@ -25,6 +25,8 @@ func URL(url, dest string) error {
 	}
 	defer f.Close()
 
+	log.Printf("FETCH %q -> %q", url, dest)
+
 	resp, err := http.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to fetch %q: %w", url, err)
@@ -36,7 +38,6 @@ func URL(url, dest string) error {
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
-	log.Printf("FETCH %q -> %q", url, dest)
 	return nil
 }
 

--- a/tools/meta/fileutil/fileutil.go
+++ b/tools/meta/fileutil/fileutil.go
@@ -2,6 +2,13 @@
 package fileutil
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
 	"meta/exec"
 )
 
@@ -10,4 +17,28 @@ func Copy(src, dest string) error {
 	// There's probably a better way to do this, but we know that cp will
 	// handle permission and mode bits correctly. So just use that.
 	return exec.Command("cp", src, dest).Run()
+}
+
+// Verify the given file has the given sha256 hashsum.
+func Verify(file, want string) error {
+	log.Printf("VERIFY %q (%s)", file, want)
+
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+
+	hs := hex.EncodeToString(h.Sum(nil))
+	if hs != want {
+		return fmt.Errorf("hashes do not match got %q, but wanted %q", hs, want)
+	}
+
+	log.Printf("VERIFY OK %q ", file)
+	return nil
 }


### PR DESCRIPTION
Github's LFS storage is very restrictive, and somewhat expensive.
Probably the wrong choice for hosting a single file like this. Instead
I've put it in a cloud provider, and added some extra logic to verify
the downloaded file.