### PR TITLE
travis: Don't upgrade packages

### DIFF
--- a/scripts/travis/common.sh
+++ b/scripts/travis/common.sh
@@ -17,9 +17,8 @@ setup() {
     if test -n "${IN_DEBUG_MODE}"; then
         return 0
     fi
-    sudo apt-get update && \
-        sudo apt-get upgrade -y && \
-        sudo apt-get install -y \
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get update -y && \
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
             clang-9 \
             clang-tidy-9 \
             cmake \


### PR DESCRIPTION
A substantial amount of test time is upgrading test image packages.
Since we only use a small number of packages, it seems like we should
avoid this step to speed up the tests. If we need newer versions of any
particular package that can be handled as a one-off.