### PR TITLE
Make `-f` option faster for large numbers of URIs

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -1,5 +1,8 @@
 #include <cassert>
-#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <ostream>
 #include <string_view>
 
 #include <absl/strings/numbers.h>
@@ -207,9 +210,11 @@ std::variant<Parser::State, ParseError> Parser::ConsumeInternal(
     switch (state_) {
         case kFile:
             if (arg == "-") {
-                opts_.file_in = stdin;
+                opts_.file_in = &std::cin;
             } else {
-                opts_.file_in = fopen(arg.data(), "r");
+                std::string filepath(arg);
+                opts_.InternalTakeIstream(
+                    std::make_unique<std::ifstream>(filepath));
             }
             return kNone;
         case kHost:
@@ -274,6 +279,9 @@ std::variant<Options, ParseError> Options::Parse(
     return p.Finish();
 }
 
-void PrintHelp(FILE* output) { fputs(kHelpMessage, output); }
+std::ostream& DisplayHelp(std::ostream& output) {
+    output << kHelpMessage;
+    return output;
+}
 
 }  // namespace ashuffle

--- a/src/args.h
+++ b/src/args.h
@@ -1,7 +1,7 @@
 #ifndef __ASHUFFLE_ARGS_H__
 #define __ASHUFFLE_ARGS_H__
 
-#include <cstdio>
+#include <istream>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -31,7 +31,7 @@ class Options {
    public:
     std::vector<Rule> ruleset;
     unsigned queue_only = 0;
-    FILE *file_in = nullptr;
+    std::istream *file_in = nullptr;
     bool check_uris = true;
     unsigned queue_buffer = 0;
     std::optional<std::string> host = {};
@@ -57,10 +57,26 @@ class Options {
         }
         return Options::Parse(tag_parser, args);
     }
+
+    // Take ownership fo the given istream, and set the file_in member to
+    // point to the referenced istream. This should only be used while the
+    // Options are being constructed.
+    void InternalTakeIstream(std::unique_ptr<std::istream> &&is) {
+        file_in = is.get();
+        owned_file_ = std::move(is);
+    };
+
+   private:
+    // The owned_file is set if this Options class owns the file_in ptr.
+    // The file_in ptr is only *sometimes* owned. For example, the file_in ptr
+    // may point to std::cin, which has static lifetime, and is not owned by
+    // this object.
+    std::unique_ptr<std::istream> owned_file_;
 };
 
-// Print the help message on the given output stream.
-void PrintHelp(FILE *output_stream);
+// Print the help message on the given output stream, and return the input
+// ostream.
+std::ostream &DisplayHelp(std::ostream &);
 
 }  // namespace ashuffle
 

--- a/src/load.cc
+++ b/src/load.cc
@@ -39,16 +39,6 @@ bool FileLoader::Verify(std::string_view) {
 
 void FileLoader::Load(ShuffleChain *songs) {
     for (std::string uri; std::getline(*file_, uri);) {
-        if (uri.empty()) {
-            Die("invalid URI in input stream");
-        }
-
-        // If this line has terminating newline attached, set it to null
-        // (effectively removing the newline).
-        if (uri[uri.size() - 1] == '\n') {
-            uri.pop_back();
-        }
-
         if (!Verify(uri)) {
             continue;
         }

--- a/src/load.cc
+++ b/src/load.cc
@@ -6,12 +6,20 @@
 
 namespace ashuffle {
 
-namespace {
+/* build the list of songs to shuffle from using MPD */
+void MPDLoader::Load(ShuffleChain *songs) {
+    std::unique_ptr<mpd::SongReader> reader = mpd_->ListAll();
+    while (!reader->Done()) {
+        std::unique_ptr<mpd::Song> song = *reader->Next();
+        if (!Verify(*song)) {
+            continue;
+        }
+        songs->Add(song->URI());
+    }
+}
 
-/* check wheter a song is allowed by the given ruleset */
-bool RulesetAcceptsSong(const std::vector<Rule> &ruleset,
-                        const mpd::Song &song) {
-    for (const Rule &rule : ruleset) {
+bool MPDLoader::Verify(const mpd::Song &song) {
+    for (const Rule &rule : rules_) {
         if (!rule.Accepts(song)) {
             return false;
         }
@@ -19,76 +27,31 @@ bool RulesetAcceptsSong(const std::vector<Rule> &ruleset,
     return true;
 }
 
-}  // namespace
-
-/* build the list of songs to shuffle from using MPD */
-void MPDLoader::Load(ShuffleChain *songs) {
-    std::unique_ptr<mpd::SongReader> reader = mpd_->ListAll();
-    while (!reader->Done()) {
-        std::unique_ptr<mpd::Song> song = *reader->Next();
-        if (RulesetAcceptsSong(rules_, *song)) {
-            songs->Add(song->URI());
-        }
+FileMPDLoader::FileMPDLoader(mpd::MPD *mpd, const std::vector<Rule> &ruleset,
+                             std::istream *file)
+    : MPDLoader(mpd, ruleset), file_(file) {
+    for (std::string uri; std::getline(*file_, uri);) {
+        valid_uris_.emplace_back(uri);
     }
+    std::sort(valid_uris_.begin(), valid_uris_.end());
 }
 
-bool FileLoader::Verify(std::string_view) {
-    // The base file loader verifies all songs. It's the "no-check" version.
-    return true;
+bool FileMPDLoader::Verify(const mpd::Song &song) {
+    if (!std::binary_search(valid_uris_.begin(), valid_uris_.end(),
+                            song.URI())) {
+        // If the URI for this song is not in the list of valid_uris_, then
+        // it shouldn't be loaded by this loader.
+        return false;
+    }
+
+    // Otherwise, just check against the normal rules.
+    return MPDLoader::Verify(song);
 }
 
 void FileLoader::Load(ShuffleChain *songs) {
     for (std::string uri; std::getline(*file_, uri);) {
-        if (!Verify(uri)) {
-            continue;
-        }
-
         songs->Add(uri);
     }
-}
-
-CheckFileLoader::CheckFileLoader(mpd::MPD *mpd,
-                                 const std::vector<Rule> &ruleset,
-                                 std::istream *file)
-    : FileLoader(file), mpd_(mpd), rules_(ruleset) {
-    std::unique_ptr<mpd::SongReader> reader = mpd->ListAll();
-    while (!reader->Done()) {
-        all_uris_.push_back((*reader->Next())->URI());
-    }
-    std::sort(all_uris_.begin(), all_uris_.end());
-}
-
-bool CheckFileLoader::Verify(std::string_view uri) {
-    if (all_uris_.empty()) {
-        // No URIs in MPD, so the song can't possibly exist.
-        return false;
-    }
-
-    if (!std::binary_search(all_uris_.begin(), all_uris_.end(), uri)) {
-        // We have some uris in `all_uris', but the given URI
-        // is not in there. Skip this URI.
-        return false;
-    }
-
-    if (rules_.empty()) {
-        // If the song does exist in MPD's library, and we don't have any
-        // rules to check, then we're done \o/.
-        return true;
-    }
-
-    // If we think the song actually exists, and we have rules to verify,
-    // then we need to fetch the song from MPD. This is quite expensive
-    // unfortunately :(.
-
-    std::optional<std::unique_ptr<mpd::Song>> song = mpd_->Search(uri);
-    // The song doesn't exist in MPD's database, can't match ruleset.
-    if (!song) {
-        std::cerr << absl::StrFormat("Song URI '%s' not found", uri)
-                  << std::endl;
-        return false;
-    }
-
-    return RulesetAcceptsSong(rules_, **song);
 }
 
 }  // namespace ashuffle

--- a/src/load.h
+++ b/src/load.h
@@ -1,7 +1,7 @@
 #ifndef __ASHUFFLE_LOAD_H__
 #define __ASHUFFLE_LOAD_H__
 
-#include <stdio.h>
+#include <istream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -36,8 +36,8 @@ class MPDLoader : public Loader {
 
 class FileLoader : public Loader {
    public:
-    ~FileLoader() override;
-    FileLoader(FILE* file) : file_(file){};
+    ~FileLoader() override = default;
+    FileLoader(std::istream* file) : file_(file){};
 
     void Load(ShuffleChain* into) override;
 
@@ -45,14 +45,14 @@ class FileLoader : public Loader {
     virtual bool Verify(std::string_view);
 
    private:
-    FILE* file_;
+    std::istream* file_;
 };
 
 class CheckFileLoader : public FileLoader {
    public:
     ~CheckFileLoader() override = default;
     CheckFileLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset,
-                    FILE* file);
+                    std::istream* file);
 
    protected:
     bool Verify(std::string_view) override;

--- a/src/load.h
+++ b/src/load.h
@@ -29,9 +29,26 @@ class MPDLoader : public Loader {
 
     void Load(ShuffleChain* into) override;
 
+   protected:
+    virtual bool Verify(const mpd::Song&);
+
    private:
     mpd::MPD* mpd_;
     const std::vector<Rule>& rules_;
+};
+
+class FileMPDLoader : public MPDLoader {
+   public:
+    ~FileMPDLoader() override = default;
+    FileMPDLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset,
+                  std::istream* file);
+
+   protected:
+    bool Verify(const mpd::Song&) override;
+
+   private:
+    std::istream* file_;
+    std::vector<std::string> valid_uris_;
 };
 
 class FileLoader : public Loader {
@@ -41,26 +58,8 @@ class FileLoader : public Loader {
 
     void Load(ShuffleChain* into) override;
 
-   protected:
-    virtual bool Verify(std::string_view);
-
    private:
     std::istream* file_;
-};
-
-class CheckFileLoader : public FileLoader {
-   public:
-    ~CheckFileLoader() override = default;
-    CheckFileLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset,
-                    std::istream* file);
-
-   protected:
-    bool Verify(std::string_view) override;
-
-   private:
-    mpd::MPD* mpd_;
-    const std::vector<Rule>& rules_;
-    std::vector<std::string> all_uris_;
 };
 
 }  // namespace ashuffle

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include <cassert>
@@ -26,8 +25,7 @@ const int kWindowSize = 7;
 
 std::unique_ptr<Loader> BuildLoader(mpd::MPD* mpd, const Options& opts) {
     if (opts.file_in != nullptr && opts.check_uris) {
-        return std::make_unique<CheckFileLoader>(mpd, opts.ruleset,
-                                                 opts.file_in);
+        return std::make_unique<FileMPDLoader>(mpd, opts.ruleset, opts.file_in);
     } else if (opts.file_in != nullptr) {
         return std::make_unique<FileLoader>(opts.file_in);
     }
@@ -43,15 +41,15 @@ int main(int argc, const char* argv[]) {
     if (ParseError* err = std::get_if<ParseError>(&parse); err != nullptr) {
         switch (err->type) {
             case ParseError::Type::kUnknown:
-                fprintf(stderr,
-                        "unknown option parsing error. Please file a bug "
-                        "at https://github.com/joshkunz/ashuffle");
+                std::cerr << "unknown option parsing error. Please file a bug "
+                          << "at https://github.com/joshkunz/ashuffle"
+                          << std::endl;
                 break;
             case ParseError::Type::kHelp:
                 // We always print the help, so just break here.
                 break;
             case ParseError::Type::kGeneric:
-                fprintf(stderr, "error: %s\n", err->msg.data());
+                std::cerr << "error: " << err->msg << std::endl;
                 break;
             default:
                 assert(false && "unreachable");
@@ -89,10 +87,11 @@ int main(int argc, const char* argv[]) {
     }
 
     if (songs.Len() == 0) {
-        fputs("Song pool is empty.", stderr);
+        std::cerr << "Song pool is empty." << std::endl;
         exit(EXIT_FAILURE);
     }
-    printf("Picking random songs out of a pool of %u.\n", songs.Len());
+    std::cout << "Picking random songs out of a pool of " << songs.Len() << "."
+              << std::endl;
 
     /* Seed the random number generator */
     srand(time(NULL));
@@ -102,7 +101,7 @@ int main(int argc, const char* argv[]) {
         for (unsigned i = 0; i < options.queue_only; i++) {
             mpd->Add(songs.Pick());
         }
-        printf("Added %u songs.\n", options.queue_only);
+        std::cout << "Added " << options.queue_only << " songs." << std::endl;
     } else {
         Loop(mpd.get(), &songs, options);
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -56,11 +56,11 @@ int main(int argc, const char* argv[]) {
             default:
                 assert(false && "unreachable");
         }
-        PrintHelp(stderr);
+        std::cerr << DisplayHelp;
         exit(EXIT_FAILURE);
     }
 
-    Options options = std::get<Options>(parse);
+    Options options = std::move(std::get<Options>(parse));
 
     std::function<std::string()> pass_f = [] {
         return GetPass(stdin, stdout, "mpd password: ");

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <iostream>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -19,8 +19,10 @@
 using namespace ashuffle;
 
 using ::testing::HasSubstr;
+using ::testing::IsNull;
 using ::testing::Matcher;
 using ::testing::MatchesRegex;
+using ::testing::NotNull;
 using ::testing::Values;
 
 TEST(ParseTest, Empty) {
@@ -28,11 +30,11 @@ TEST(ParseTest, Empty) {
     auto result = Options::Parse(tagger, std::vector<std::string>());
     ASSERT_EQ(std::get_if<ParseError>(&result), nullptr);
 
-    Options opts = std::get<Options>(result);
+    Options opts = std::move(std::get<Options>(result));
 
     EXPECT_TRUE(opts.ruleset.empty()) << "there should be no rules by default";
     EXPECT_EQ(opts.queue_only, 0U);
-    EXPECT_EQ(opts.file_in, nullptr);
+    EXPECT_THAT(opts.file_in, IsNull());
     EXPECT_TRUE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 0U);
     EXPECT_EQ(opts.host, std::nullopt);
@@ -58,7 +60,7 @@ TEST(ParseTest, Short) {
 
     EXPECT_EQ(opts.ruleset.size(), 2U);
     EXPECT_EQ(opts.queue_only, 5U);
-    EXPECT_NE(opts.file_in, nullptr);
+    EXPECT_THAT(opts.file_in, NotNull());
     EXPECT_FALSE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.port, 1234U);
@@ -84,7 +86,7 @@ TEST(ParseTest, Long) {
 
     EXPECT_EQ(opts.ruleset.size(), 2U);
     EXPECT_EQ(opts.queue_only, 5U);
-    EXPECT_NE(opts.file_in, nullptr);
+    EXPECT_THAT(opts.file_in, NotNull());
     EXPECT_FALSE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.host, "foo");
@@ -109,7 +111,7 @@ TEST(ParseTest, MixedLongShort) {
 
     EXPECT_EQ(opts.ruleset.size(), 2U);
     EXPECT_EQ(opts.queue_only, 5U);
-    EXPECT_NE(opts.file_in, nullptr);
+    EXPECT_THAT(opts.file_in, NotNull());
     EXPECT_FALSE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 10U);
 }
@@ -142,10 +144,10 @@ TEST(ParseTest, FileInStdin) {
     fake::TagParser tagger;
 
     opts = std::get<Options>(Options::Parse(tagger, {"-f", "-"}));
-    EXPECT_EQ(opts.file_in, stdin);
+    EXPECT_EQ(opts.file_in, &std::cin);
 
     opts = std::get<Options>(Options::Parse(tagger, {"--file", "-"}));
-    EXPECT_EQ(opts.file_in, stdin);
+    EXPECT_EQ(opts.file_in, &std::cin);
 }
 
 using ParseFailureParam =

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -421,6 +421,10 @@ func TestFastStartup(t *testing.T) {
 			name: "from file",
 			args: []string{"-f", dbF.Path(), "-o", "1"},
 		},
+		{
+			name: "from file, with filter",
+			args: []string{"-f", dbF.Path(), "-o", "1", "-e", "artist", "AA"},
+		},
 	}
 
 	for _, test := range tests {

--- a/t/load_test.cc
+++ b/t/load_test.cc
@@ -78,7 +78,7 @@ TEST(FileLoaderTest, Basic) {
     EXPECT_THAT(chain.Items(), WhenSorted(ContainerEq(want)));
 }
 
-TEST(CheckFileLoaderTest, Basic) {
+TEST(FileMPDLoaderTest, Basic) {
     // step 1. Initialize the MPD connection.
     fake::MPD mpd;
 
@@ -120,7 +120,7 @@ TEST(CheckFileLoaderTest, Basic) {
     });
 
     // step 6. Run! (and validate)
-    CheckFileLoader loader(static_cast<mpd::MPD *>(&mpd), ruleset, s.get());
+    FileMPDLoader loader(static_cast<mpd::MPD *>(&mpd), ruleset, s.get());
     loader.Load(&chain);
 
     std::vector<std::string> want = {song_a.URI(), song_c.URI()};


### PR DESCRIPTION
Should address the slow startup behavior observed in #31 and mentioned in #48. This PR also includes a regression test for this performance issue in the integration test suite.