### PR TITLE
Add `--group-by` to shuffle groups instead of individual songs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,11 @@ absl_libs = [
     'int128',
     'str_format_internal',
     'strings_internal',
-    'strings'
+    'strings',
+
+    # Via Hash:
+    'hash',
+    'city',
 ]
 
 absl_deps = []

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -11,7 +11,7 @@ function die() {
 # Use the environment variables by default.
 MPD_VERSION="${MPD_VERSION:-}"
 LIBMPDCLIENT_VERSION="${LIBMPDCLIENT_VERSION:-}"
-
+IMAGE_TAG="${IMAGE_TAG:-test/mpd:latest}"
 
 declare -a DOCKER_ARGS
 while test "$#" -gt 0; do
@@ -24,6 +24,10 @@ while test "$#" -gt 0; do
             LIBMPDCLIENT_VERSION="$2"
             shift 2
             ;;
+        -t|--image-tag)
+            IMAGE_TAG="$2"
+            shift 2
+            ;;
         *)
             DOCKER_ARGS+=( "$1" )
             shift
@@ -32,10 +36,6 @@ while test "$#" -gt 0; do
 done
 
 cd $(git rev-parse --show-toplevel)
-
-if test -d "${TEMPDIR}"; then
-    die "Directory /tmp exists, can't create stage"
-fi
 
 mkdir "${TEMPDIR}"
 STAGE_DIR=$(mktemp -p "${TEMPDIR}" --directory)
@@ -59,18 +59,18 @@ case "${IMAGE_BASE}" in
             args+=( "--build-arg" "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" )
         fi
         docker build "${args[@]}" --build-arg "STAGE_DIR=${STAGE_DIR}" \
-            -t "test/mpd:latest" -f ./t/docker/Dockerfile.ubuntu .
+            -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.ubuntu .
         ;;
     alpine)
         if test -n "${MPD_VERSION}" || test -n "${LIBMPDCLIENT_VERSION}"; then
             die "alpine does not support setting mpd/libmpdclient version"
         fi
         docker build --build-arg "STAGE_DIR=${STAGE_DIR}" \
-            -t "test/mpd:latest" -f ./t/docker/Dockerfile.alpine .
+            -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.alpine .
         ;;
     *)
         die "invalid image base: ${IMAGE_BASE}"
 esac
 
 rm -r "${STAGE_DIR}"
-rm -r "${TEMPDIR}"
+rmdir --ignore-fail-on-non-empty "${TEMPDIR}"

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -23,7 +23,6 @@ function check_c() {
     fi
 }
 
-
 while read F; do
     if test -z "$F"; then continue; fi
     case "$F" in

--- a/scripts/run-integration
+++ b/scripts/run-integration
@@ -4,5 +4,20 @@ die() {
     exit 1
 }
 
-./scripts/build-test-image "$@" || die "couldn't build test image"
-exec docker run --name mpd_test --rm -it test/mpd:latest
+run_id="$(head -c 100 /dev/urandom | sha256sum | head -c 30)"
+
+tagname="test/ashuffle:run_${run_id}"
+
+tty="-t"
+extra=()
+
+while test $# -gt 0; do
+    case "$1" in
+        --no_tty) tty="" ;;
+        *) extra+=( "$1" ) ;;
+    esac
+    shift
+done
+
+./scripts/build-test-image --image-tag "${tagname}" "${extra[@]}" || die "couldn't build test image"
+exec docker run --name "ashuffle_integration_run_${run_id}" --rm $tty -i "${tagname}"

--- a/scripts/travis/check-format
+++ b/scripts/travis/check-format
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+. "scripts/travis/common.sh"
+
+sudo env DEBIAN_FRONTEND=noninteractive apt-get update -y && \
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y clang-format-9 \
+    || die "failed to update clang-format-9"
+
+CLANG_FORMAT=clang-format-9
+
 declare -a BAD_FORMAT
 
 function check_go() {
@@ -12,12 +20,13 @@ function check_go() {
 
 function check_c() {
     F=$1
-    cmp "$F" <(clang-format "$F") >/dev/null
+    cmp "$F" <("${CLANG_FORMAT}" "$F") >/dev/null
     if test $? -ne 0; then
         BAD_FORMAT+=( "$F" )
     fi
 }
 
+"${CLANG_FORMAT}" --version
 
 while read F; do
     if test -z "$F"; then continue; fi

--- a/src/args.cc
+++ b/src/args.cc
@@ -27,12 +27,11 @@ constexpr char kHelpMessage[] =
     "                     filename to retrive URI's from standard in. This\n"
     "                     can be used to pipe song URI's from another program\n"
     "                     into ashuffle.\n"
-    "   -g,--group-by     Shuffle songs grouped by the given tags. For "
-    "example\n"
-    "                     'album' could be used as the tag, and an entire\n"
-    "                     album's worth of songs would be queued instead of "
-    "one\n"
-    "                     song at a time.\n"
+    "   --by-album        Same as '--group-by album date'.\n"
+    "   -g,--group-by     Shuffle songs grouped by the given tags. For\n"
+    "                     example 'album' could be used as the tag, and an\n"
+    "                     entire album's worth of songs would be queued\n"
+    "                     instead of one song at a time.\n"
     "   --host            Specify a hostname or IP address to connect to.\n"
     "                     Defaults to `localhost`.\n"
     "   -n,--no-check     When reading URIs from a file, don't check to\n"
@@ -217,7 +216,20 @@ std::variant<Parser::State, ParseError> Parser::ConsumeInternal(
             return kTest;
         }
         if (arg == "--group-by" || arg == "-g") {
+            if (!opts_.group_by.empty()) {
+                return ParseError(
+                    absl::StrFormat("'%s' can only be provided once", arg));
+            }
             return kGroupBegin;
+        }
+        if (arg == "--by-album") {
+            if (!opts_.group_by.empty()) {
+                return ParseError(
+                    absl::StrFormat("'%s' can only be provided once", arg));
+            }
+            opts_.group_by.push_back(MPD_TAG_ALBUM);
+            opts_.group_by.push_back(MPD_TAG_DATE);
+            return kNone;
         }
     }
     switch (state_) {

--- a/src/args.h
+++ b/src/args.h
@@ -40,6 +40,7 @@ class Options {
     struct {
         bool print_all_songs_and_exit = false;
     } test = {};
+    std::vector<enum mpd_tag_type> group_by = {};
 
     // Parse parses the arguments in the given vector and returns ParseResult
     // based on the success/failure of the parse.

--- a/src/ashuffle.cc
+++ b/src/ashuffle.cc
@@ -74,15 +74,18 @@ void TryEnqueue(mpd::MPD *mpd, ShuffleChain *songs, const Options &options) {
     /* Add another song to the list and restart the player */
     if (should_add) {
         if (options.queue_buffer != 0) {
-            unsigned to_enqueue = options.queue_buffer;
+            int needed = static_cast<int>(options.queue_buffer) -
+                         static_cast<int>(queue_songs_remaining);
             // If we're not currently "on" a song, then we need to not only
             // enqueue options->queue_buffer songs, but also the song we're
             // about to play, so increment the `to_enqueue' count by one.
             if (past_last || queue_empty) {
-                to_enqueue += 1;
+                needed += 1;
             }
-            for (unsigned i = queue_songs_remaining; i < to_enqueue; i++) {
-                mpd->Add(songs->Pick());
+            while (needed > 0) {
+                std::vector<std::string> picked = songs->Pick();
+                needed -= static_cast<int>(picked.size());
+                mpd->Add(picked);
             }
         } else {
             mpd->Add(songs->Pick());

--- a/src/load.h
+++ b/src/load.h
@@ -6,6 +6,8 @@
 #include <string_view>
 #include <vector>
 
+#include <mpd/tag.h>
+
 #include "mpd.h"
 #include "rule.h"
 #include "shuffle.h"
@@ -25,7 +27,10 @@ class MPDLoader : public Loader {
    public:
     ~MPDLoader() override = default;
     MPDLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset)
-        : mpd_(mpd), rules_(ruleset){};
+        : MPDLoader(mpd, ruleset, std::vector<enum mpd_tag_type>()){};
+    MPDLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset,
+              const std::vector<enum mpd_tag_type>& group_by)
+        : mpd_(mpd), rules_(ruleset), group_by_(group_by){};
 
     void Load(ShuffleChain* into) override;
 
@@ -35,12 +40,14 @@ class MPDLoader : public Loader {
    private:
     mpd::MPD* mpd_;
     const std::vector<Rule>& rules_;
+    const std::vector<enum mpd_tag_type> group_by_;
 };
 
 class FileMPDLoader : public MPDLoader {
    public:
     ~FileMPDLoader() override = default;
     FileMPDLoader(mpd::MPD* mpd, const std::vector<Rule>& ruleset,
+                  const std::vector<enum mpd_tag_type>& group_by,
                   std::istream* file);
 
    protected:

--- a/src/main.cc
+++ b/src/main.cc
@@ -83,9 +83,10 @@ int main(int argc, const char* argv[]) {
     // For integration testing, we sometimes just want to have ashuffle
     // dump the list of songs in its shuffle chain.
     if (options.test.print_all_songs_and_exit) {
-        std::vector<std::string> all_songs = songs.Items();
-        for (auto song : all_songs) {
-            std::cout << song << std::endl;
+        for (auto&& group : songs.Items()) {
+            for (auto&& song : group) {
+                std::cout << song << std::endl;
+            }
         }
         exit(EXIT_SUCCESS);
     }
@@ -94,8 +95,15 @@ int main(int argc, const char* argv[]) {
         std::cerr << "Song pool is empty." << std::endl;
         exit(EXIT_FAILURE);
     }
-    std::cout << "Picking random songs out of a pool of " << songs.Len() << "."
-              << std::endl;
+
+    if (!options.group_by.empty()) {
+        std::cout << absl::StrFormat("Picking from %u groups (%u songs).",
+                                     songs.Len(), songs.LenURIs())
+                  << std::endl;
+    } else {
+        std::cout << "Picking random songs out of a pool of " << songs.Len()
+                  << "." << std::endl;
+    }
 
     /* Seed the random number generator */
     srand(time(NULL));

--- a/src/main.cc
+++ b/src/main.cc
@@ -60,6 +60,10 @@ int main(int argc, const char* argv[]) {
 
     Options options = std::move(std::get<Options>(parse));
 
+    if (!options.group_by.empty()) {
+        std::cerr << "-g/--group-by not yet supported" << std::endl;
+    }
+
     std::function<std::string()> pass_f = [] {
         return GetPass(stdin, stdout, "mpd password: ");
     };

--- a/src/main.cc
+++ b/src/main.cc
@@ -85,7 +85,12 @@ int main(int argc, const char* argv[]) {
     // For integration testing, we sometimes just want to have ashuffle
     // dump the list of songs in its shuffle chain.
     if (options.test.print_all_songs_and_exit) {
+        bool first = true;
         for (auto&& group : songs.Items()) {
+            if (!first) {
+                std::cout << "---" << std::endl;
+            }
+            first = false;
             for (auto&& song : group) {
                 std::cout << song << std::endl;
             }

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,12 +25,13 @@ const int kWindowSize = 7;
 
 std::unique_ptr<Loader> BuildLoader(mpd::MPD* mpd, const Options& opts) {
     if (opts.file_in != nullptr && opts.check_uris) {
-        return std::make_unique<FileMPDLoader>(mpd, opts.ruleset, opts.file_in);
+        return std::make_unique<FileMPDLoader>(mpd, opts.ruleset, opts.group_by,
+                                               opts.file_in);
     } else if (opts.file_in != nullptr) {
         return std::make_unique<FileLoader>(opts.file_in);
     }
 
-    return std::make_unique<MPDLoader>(mpd, opts.ruleset);
+    return std::make_unique<MPDLoader>(mpd, opts.ruleset, opts.group_by);
 }
 
 }  // namespace
@@ -60,8 +61,9 @@ int main(int argc, const char* argv[]) {
 
     Options options = std::move(std::get<Options>(parse));
 
-    if (!options.group_by.empty()) {
-        std::cerr << "-g/--group-by not yet supported" << std::endl;
+    if (!options.check_uris && !options.group_by.empty()) {
+        std::cerr << "-g/--group-by not supported with no-check" << std::endl;
+        exit(EXIT_FAILURE);
     }
 
     std::function<std::string()> pass_f = [] {

--- a/src/mpd.h
+++ b/src/mpd.h
@@ -129,6 +129,14 @@ class MPD {
     // Add, adds the song wit the given URI to the MPD queue.
     virtual void Add(const std::string& uri) = 0;
 
+    // Add also works on vectors of URIs, by repeatedly invoking Add for each
+    // element.
+    void Add(const std::vector<std::string>& uris) {
+        for (auto& u : uris) {
+            Add(u);
+        }
+    };
+
     enum PasswordStatus {
         kAccepted,
         kRejected,

--- a/src/mpd_client.cc
+++ b/src/mpd_client.cc
@@ -168,8 +168,7 @@ class MPDImpl : public MPD {
 
 class SongReaderImpl : public SongReader {
    public:
-    SongReaderImpl(MPDImpl& mpd)
-        : mpd_(mpd), song_(std::nullopt), has_song_(false){};
+    SongReaderImpl(MPDImpl& mpd) : mpd_(mpd), song_(std::nullopt){};
 
     // SongReaderImpl is also pointer owning (the pointer to the next song_).
     SongReaderImpl(SongReaderImpl&) = delete;
@@ -193,11 +192,10 @@ class SongReaderImpl : public SongReader {
 
     MPDImpl& mpd_;
     std::optional<std::unique_ptr<Song>> song_;
-    bool has_song_;
 };
 
 void SongReaderImpl::FetchNext() {
-    if (has_song_) {
+    if (song_) {
         return;
     }
     struct mpd_song* raw_song = mpd_recv_song(mpd_.mpd_);
@@ -214,13 +212,11 @@ void SongReaderImpl::FetchNext() {
         song_ = std::nullopt;
         return;
     }
-    has_song_ = true;
     song_ = std::unique_ptr<Song>(new SongImpl(raw_song));
 }
 
 std::optional<std::unique_ptr<Song>> SongReaderImpl::Next() {
     FetchNext();
-    has_song_ = false;
     return std::exchange(song_, std::nullopt);
 }
 

--- a/src/shuffle.h
+++ b/src/shuffle.h
@@ -3,9 +3,23 @@
 
 #include <deque>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace ashuffle {
+
+class ShuffleChain;
+
+class ShuffleItem {
+   public:
+    template <typename T>
+    ShuffleItem(T v) : ShuffleItem(std::vector<std::string>{v}){};
+    ShuffleItem(std::vector<std::string> uris) : _uris(uris){};
+
+   private:
+    std::vector<std::string> _uris;
+    friend class ShuffleChain;
+};
 
 class ShuffleChain {
    public:
@@ -20,25 +34,29 @@ class ShuffleChain {
 
     // Add a string to the pool of songs that can be picked out of this
     // chain.
-    void Add(std::string);
+    void Add(ShuffleItem i);
 
-    // Return the total length (window + pool) of this chain.
+    // Return the total number of Items (groups) in this chain.
     unsigned Len();
 
-    // Pick a random song out of this chain.
-    std::string Pick();
+    // Return the total number of URIs in this chain, in all items.
+    unsigned LenURIs();
+
+    // Pick a group of songs out of this chain.
+    const std::vector<std::string>& Pick();
 
     // Items returns a vector of all items in this chain. This operation is
     // extremely heavyweight, since it copies most of the storage used by
     // the chain. Use with caution.
-    std::vector<std::string> Items();
+    std::vector<std::vector<std::string>> Items();
 
    private:
     void FillWindow();
 
     unsigned _max_window;
-    std::deque<std::string> _window;
-    std::deque<std::string> _pool;
+    std::vector<ShuffleItem> _items;
+    std::deque<int> _window;
+    std::deque<int> _pool;
 };
 
 }  // namespace ashuffle

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -156,6 +156,15 @@ TEST(ParseTest, FileInStdin) {
     EXPECT_EQ(opts.file_in, &std::cin);
 }
 
+TEST(ParseTest, ByAlbum) {
+    Options opts;
+    fake::TagParser tagger;
+
+    opts = std::get<Options>(Options::Parse(fake::TagParser(), {"--by-album"}));
+    EXPECT_THAT(opts.group_by, ElementsAre(MPD_TAG_ALBUM, MPD_TAG_DATE))
+        << "--by-album should be equivalent to --group-by album date";
+}
+
 using ParseFailureParam =
     std::tuple<std::vector<std::string>, Matcher<std::string>>;
 
@@ -211,6 +220,12 @@ std::vector<ParseFailureParam> partial_cases = {
      HasSubstr("no argument supplied for '--test_enable_option_do_not_use'")},
     {{"-g"}, HasSubstr("no argument supplied for '-g'")},
     {{"--group-by"}, HasSubstr("no argument supplied for '--group-by'")},
+    {{"-g", "artist", "--by-album"},
+     HasSubstr("'--by-album' can only be provided once")},
+    {{"-g", "artist", "-g", "invalid"},
+     HasSubstr("'-g' can only be provided once")},
+    {{"--by-album", "-g", "artist"},
+     HasSubstr("'-g' can only be provided once")},
 };
 
 INSTANTIATE_TEST_SUITE_P(Partials, ParseFailureTest, ValuesIn(partial_cases));

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -18,6 +18,7 @@
 
 using namespace ashuffle;
 
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::IsNull;
 using ::testing::Matcher;
@@ -40,6 +41,7 @@ TEST(ParseTest, Empty) {
     EXPECT_EQ(opts.host, std::nullopt);
     EXPECT_EQ(opts.port, 0U);
     EXPECT_FALSE(opts.test.print_all_songs_and_exit);
+    EXPECT_TRUE(opts.group_by.empty());
 }
 
 TEST(ParseTest, Short) {
@@ -55,6 +57,7 @@ TEST(ParseTest, Short) {
         "-e", "artist", "test artist", "artist", "another one",
         "-f", "/dev/zero",
         "-p", "1234",
+        "-g", "artist",
     }));
     // clang-format on
 
@@ -64,6 +67,7 @@ TEST(ParseTest, Short) {
     EXPECT_FALSE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.port, 1234U);
+    EXPECT_THAT(opts.group_by, ElementsAre(MPD_TAG_ARTIST));
 }
 
 TEST(ParseTest, Long) {
@@ -81,6 +85,7 @@ TEST(ParseTest, Long) {
             "--queue-buffer", "10",
             "--host", "foo",
             "--port", "1234",
+            "--group-by", "artist",
     }));
     // clang-format on
 
@@ -91,6 +96,7 @@ TEST(ParseTest, Long) {
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.host, "foo");
     EXPECT_EQ(opts.port, 1234U);
+    EXPECT_THAT(opts.group_by, ElementsAre(MPD_TAG_ARTIST));
 }
 
 TEST(ParseTest, MixedLongShort) {
@@ -203,6 +209,8 @@ std::vector<ParseFailureParam> partial_cases = {
     {{"--port"}, HasSubstr("no argument supplied for '--port'")},
     {{"--test_enable_option_do_not_use"},
      HasSubstr("no argument supplied for '--test_enable_option_do_not_use'")},
+    {{"-g"}, HasSubstr("no argument supplied for '-g'")},
+    {{"--group-by"}, HasSubstr("no argument supplied for '--group-by'")},
 };
 
 INSTANTIATE_TEST_SUITE_P(Partials, ParseFailureTest, ValuesIn(partial_cases));

--- a/t/integration/ashuffle/ashuffle.go
+++ b/t/integration/ashuffle/ashuffle.go
@@ -16,6 +16,7 @@ type Ashuffle struct {
 	cancelFunc func()
 
 	Stdout *bytes.Buffer
+	Stderr *bytes.Buffer
 }
 
 const MaxShutdownWait = 5 * time.Second
@@ -118,9 +119,9 @@ func New(ctx context.Context, path string, opts *Options) (*Ashuffle, error) {
 	runCtx, cancel := context.WithCancel(ctx)
 	var args []string
 	cmd := exec.CommandContext(runCtx, path, args...)
-	stdout := bytes.Buffer{}
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = &stderr
 
 	if opts != nil {
 		cmd.Args = append([]string{path}, opts.Args...)
@@ -144,5 +145,6 @@ func New(ctx context.Context, path string, opts *Options) (*Ashuffle, error) {
 		cmd:        cmd,
 		cancelFunc: cancel,
 		Stdout:     &stdout,
+		Stderr:     &stderr,
 	}, nil
 }

--- a/t/integration/go.mod
+++ b/t/integration/go.mod
@@ -6,4 +6,6 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fhs/gompd v2.0.0+incompatible
 	github.com/google/go-cmp v0.3.1
+	github.com/montanaflynn/stats v0.6.3
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/t/integration/go.sum
+++ b/t/integration/go.sum
@@ -4,3 +4,7 @@ github.com/fhs/gompd v2.0.0+incompatible h1:pv5XKTatya1k3r1woaWLwFQiF0BfAsgWSe5e
 github.com/fhs/gompd v2.0.0+incompatible/go.mod h1:UVZXd9wmFBH5tIXLYeI+CGUIt15ZvtGQvVO6SDHy1os=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/montanaflynn/stats v0.6.3 h1:F8446DrvIF5V5smZfZ8K9nrmmix0AFgevPdLruGOmzk=
+github.com/montanaflynn/stats v0.6.3/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -526,7 +527,7 @@ func TestFastStartup(t *testing.T) {
 
 	// Parallelism controls the number of parallel startup tests that are
 	// allowed to run at once.
-	parallelism := 10
+	parallelism := runtime.NumCPU()
 	// Trials controls the number of startup time samples that will be
 	// collected.
 	trials := 50

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -531,10 +531,10 @@ func TestFastStartup(t *testing.T) {
 	// collected.
 	trials := 50
 	// Threshold is the level at which the 95th percentile startup time is
-	// considered a "failure" for the purposes of this test. Right now it
-	// is pegged to 400ms. Note: making this threshold less than 1ms may not
-	// work, since the 95th percentile is calculated in milliseconds.
-	threshold := 400 * time.Millisecond
+	// considered a "failure" for the purposes of this test. Note: making this
+	// threshold less than 1ms may not work, since the 95th percentile is
+	// calculated in milliseconds.
+	threshold := 750 * time.Millisecond
 
 	// Start up MPD and read out the DB, so we can build a file list for the
 	// "from file" test. We will immediately shut down this instance, because

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -262,69 +262,175 @@ func TestBasic(t *testing.T) {
 	mpdi.Shutdown()
 }
 
+type Groups [][]string
+
+func (g Groups) Len() int      { return len(g) }
+func (g Groups) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
+func (g Groups) Less(i, j int) bool {
+	a, b := g[i], g[j]
+	if len(a) < len(b) {
+		return true
+	}
+	if len(b) < len(a) {
+		return false
+	}
+	for idx := range b {
+		if a[idx] < b[idx] {
+			return true
+		}
+		if a[idx] > b[idx] {
+			return false
+		}
+	}
+	return false
+}
+
+func splitGroups(lines string) Groups {
+	var groups Groups
+	var cur []string
+	for _, line := range strings.Split(strings.TrimSpace(lines), "\n") {
+		if line == "---" {
+			sort.Strings(cur)
+			groups = append(groups, cur)
+			cur = nil
+			continue
+		}
+		cur = append(cur, line)
+	}
+	if len(cur) > 0 {
+		sort.Strings(cur)
+		groups = append(groups, cur)
+	}
+	return groups
+}
+
 func TestFromFile(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	mpdi, err := mpd.New(ctx, &mpd.Options{LibraryRoot: "/music"})
-	if err != nil {
-		t.Fatalf("failed to create mpd instance: %v", err)
-	}
-
-	// These are the songs we'll ask ashuffle to use. They should all be
-	// in the integration root container.
-	db := []string{
-		"BoxCat_Games_-_10_-_Epic_Song.mp3",
-		"Broke_For_Free_-_01_-_Night_Owl.mp3",
-		"Jahzzar_-_05_-_Siesta.mp3",
-		"Monk_Turner__Fascinoma_-_01_-_Its_Your_Birthday.mp3",
-		"Tours_-_01_-_Enthusiast.mp3",
-	}
-
-	// The same as "db", but without the songs by Jahzzar and Tours
-	want := []string{
-		"BoxCat_Games_-_10_-_Epic_Song.mp3",
-		"Broke_For_Free_-_01_-_Night_Owl.mp3",
-		"Monk_Turner__Fascinoma_-_01_-_Its_Your_Birthday.mp3",
-	}
-
-	linesF, err := writeLines(db)
-	if err != nil {
-		t.Fatalf("couldn't write db lines to file: %v", err)
-	}
-	defer linesF.Cleanup()
-
-	as, err := ashuffle.New(ctx, ashuffleBin, &ashuffle.Options{
-		MPDAddress: mpdi,
-		Args: []string{
-			"--exclude", "artist", "tours",
-			// The real album name is "Traveller's Guide", partial match should
-			// work.
-			"--exclude", "artist", "jahzzar", "album", "traveller",
-			// Pass in our list of songs.
-			"-f", linesF.Path(),
-			// Then, we make ashuffle just print the list of songs and quit
-			"--test_enable_option_do_not_use", "print_all_songs_and_exit",
+	tests := []struct {
+		desc    string
+		library string
+		flags   []string
+		input   []string
+		want    Groups
+	}{
+		{
+			desc:    "With excludes",
+			library: "/music",
+			flags: []string{
+				"--exclude", "artist", "tours",
+				// The real album name is "Traveller's Guide", partial match should
+				// work.
+				"--exclude", "artist", "jahzzar", "album", "traveller",
+			},
+			input: []string{
+				"BoxCat_Games_-_10_-_Epic_Song.mp3",
+				"Broke_For_Free_-_01_-_Night_Owl.mp3",
+				"Jahzzar_-_05_-_Siesta.mp3",
+				"Monk_Turner__Fascinoma_-_01_-_Its_Your_Birthday.mp3",
+				"Tours_-_01_-_Enthusiast.mp3",
+			},
+			want: Groups{
+				{"BoxCat_Games_-_10_-_Epic_Song.mp3"},
+				{"Broke_For_Free_-_01_-_Night_Owl.mp3"},
+				{"Monk_Turner__Fascinoma_-_01_-_Its_Your_Birthday.mp3"},
+			},
 		},
-	})
-	if err != nil {
-		t.Fatalf("failed to start ashuffle: %v", err)
+		{
+			desc:    "By Album",
+			library: "/music.huge",
+			flags:   []string{"--by-album"},
+			input: []string{
+				"A/A-A/A-A-A.mp3",
+				"A/A-A/A-A-B.mp3",
+				"A/A-A/A-A-C.mp3",
+				"A/A-A/A-A-D.mp3",
+				"A/A-A/A-A-E.mp3",
+				"A/A-A/A-A-F.mp3",
+				"A/A-A/A-A-G.mp3",
+				"A/A-A/A-A-H.mp3",
+				"A/A-A/A-A-I.mp3",
+				"A/A-A/A-A-J.mp3",
+				"A/A-A/A-A-K.mp3",
+				"A/A-B/A-B-A.mp3",
+				"A/A-B/A-B-B.mp3",
+				"A/A-B/A-B-C.mp3",
+				"A/A-B/A-B-D.mp3",
+				"A/A-B/A-B-E.mp3",
+				"A/A-B/A-B-F.mp3",
+				"A/A-B/A-B-G.mp3",
+				"A/A-B/A-B-H.mp3",
+				"A/A-B/A-B-I.mp3",
+				"A/A-B/A-B-J.mp3",
+				"A/A-B/A-B-K.mp3",
+			},
+			want: Groups{
+				{
+					"A/A-A/A-A-A.mp3",
+					"A/A-A/A-A-B.mp3",
+					"A/A-A/A-A-C.mp3",
+					"A/A-A/A-A-D.mp3",
+					"A/A-A/A-A-E.mp3",
+					"A/A-A/A-A-F.mp3",
+					"A/A-A/A-A-G.mp3",
+					"A/A-A/A-A-H.mp3",
+					"A/A-A/A-A-I.mp3",
+					"A/A-A/A-A-J.mp3",
+					"A/A-A/A-A-K.mp3",
+				},
+				{
+					"A/A-B/A-B-A.mp3",
+					"A/A-B/A-B-B.mp3",
+					"A/A-B/A-B-C.mp3",
+					"A/A-B/A-B-D.mp3",
+					"A/A-B/A-B-E.mp3",
+					"A/A-B/A-B-F.mp3",
+					"A/A-B/A-B-G.mp3",
+					"A/A-B/A-B-H.mp3",
+					"A/A-B/A-B-I.mp3",
+					"A/A-B/A-B-J.mp3",
+					"A/A-B/A-B-K.mp3",
+				},
+			},
+		},
 	}
 
-	// Wait for ashuffle to exit.
-	if err := as.Shutdown(ashuffle.ShutdownSoft); err != nil {
-		t.Errorf("ashuffle did not shut down cleanly: %v", err)
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			test := test
+			t.Parallel()
+			mpdi, err := mpd.New(ctx, &mpd.Options{LibraryRoot: test.library})
+			if err != nil {
+				t.Fatalf("failed to create mpd instance: %v", err)
+			}
+			defer mpdi.Shutdown()
+
+			linesF, err := writeLines(test.input)
+			if err != nil {
+				t.Fatalf("couldn't write db lines to file: %v", err)
+			}
+			defer linesF.Cleanup()
+			as, err := ashuffle.New(ctx, ashuffleBin, &ashuffle.Options{
+				MPDAddress: mpdi,
+				Args: append(test.flags,
+					"-f", linesF.Path(),
+					"--test_enable_option_do_not_use", "print_all_songs_and_exit",
+				),
+			})
+			// Wait for ashuffle to exit.
+			if err := as.Shutdown(ashuffle.ShutdownSoft); err != nil {
+				t.Errorf("ashuffle did not shut down cleanly: %v", err)
+			}
+
+			got := splitGroups(as.Stdout.String())
+
+			sort.Sort(got)
+			sort.Sort(test.want)
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("shuffle songs differ, diff want got:\n%s", diff)
+			}
+		})
 	}
-
-	got := strings.Split(strings.TrimSpace(as.Stdout.String()), "\n")
-
-	sort.Strings(want)
-	sort.Strings(got)
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("shuffle songs differ, diff want got:\n%s", diff)
-	}
-
-	mpdi.Shutdown()
 }
 
 // Implements MPDAddress, wrapping the given MPDAddress with the appropriate

--- a/t/load_test.cc
+++ b/t/load_test.cc
@@ -29,7 +29,7 @@ TEST(MPDLoaderTest, Basic) {
     MPDLoader loader(static_cast<mpd::MPD *>(&mpd), ruleset);
     loader.Load(&chain);
 
-    std::vector<std::string> want = {"song_a", "song_b"};
+    std::vector<std::vector<std::string>> want = {{"song_a"}, {"song_b"}};
     EXPECT_THAT(chain.Items(), WhenSorted(ContainerEq(want)));
 }
 
@@ -52,7 +52,7 @@ TEST(MPDLoaderTest, WithFilter) {
     MPDLoader loader(static_cast<mpd::MPD *>(&mpd), ruleset);
     loader.Load(&chain);
 
-    std::vector<std::string> want = {"song_a", "song_c"};
+    std::vector<std::vector<std::string>> want = {{"song_a"}, {"song_c"}};
     EXPECT_THAT(chain.Items(), WhenSorted(ContainerEq(want)));
 }
 
@@ -73,7 +73,8 @@ TEST(FileLoaderTest, Basic) {
     FileLoader loader(s.get());
     loader.Load(&chain);
 
-    std::vector<std::string> want = {song_a.URI(), song_b.URI(), song_c.URI()};
+    std::vector<std::vector<std::string>> want = {
+        {song_a.URI()}, {song_b.URI()}, {song_c.URI()}};
 
     EXPECT_THAT(chain.Items(), WhenSorted(ContainerEq(want)));
 }
@@ -123,6 +124,7 @@ TEST(FileMPDLoaderTest, Basic) {
     FileMPDLoader loader(static_cast<mpd::MPD *>(&mpd), ruleset, s.get());
     loader.Load(&chain);
 
-    std::vector<std::string> want = {song_a.URI(), song_c.URI()};
+    std::vector<std::vector<std::string>> want = {{song_a.URI()},
+                                                  {song_c.URI()}};
     EXPECT_THAT(chain.Items(), WhenSorted(ContainerEq(want)));
 }

--- a/t/mpd_fake.h
+++ b/t/mpd_fake.h
@@ -50,6 +50,36 @@ class Song : public mpd::Song {
     bool operator==(const Song& other) const {
         return uri == other.uri && tags == other.tags;
     }
+
+    friend std::ostream& operator<<(std::ostream& os, const Song& s) {
+        os << "Song(\"" << s.uri << "\"";
+
+        if (s.tags.empty()) {
+            return os << ")";
+        }
+
+        os << ", {";
+        bool first = true;
+        for (auto& [tag, val] : s.tags) {
+            if (!first) {
+                os << ", ";
+            }
+            first = false;
+            std::string tag_name;
+            switch (tag) {
+                case MPD_TAG_ARTIST:
+                    tag_name = "artist";
+                    break;
+                case MPD_TAG_ALBUM:
+                    tag_name = "album";
+                    break;
+                default:
+                    tag_name = "<unknown>";
+            }
+            os << tag_name << ": " << val;
+        }
+        return os << "})";
+    }
 };
 
 class TagParser : public mpd::TagParser {
@@ -141,8 +171,8 @@ class MPD : public mpd::MPD {
         state.playing = true;
     };
     void PlayAt(unsigned position) override {
-        assert(position < queue.size() && "can't play song outside of queue");
         dbg() << "call:PlayAt(" << position << ")" << std::endl;
+        assert(position < queue.size() && "can't play song outside of queue");
         state.song_position = position;
         state.playing = true;
     };


### PR DESCRIPTION
This PR addresses issues like #8 and #43, allowing users to shuffle by whatever subgroups they want. It also adds a handy `--by-album` flag that groups by album.