### PR TITLE
Allow using system absl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,34 +1,51 @@
 project('ashuffle', ['c', 'cpp'], default_options: ['cpp_std=c++17', 'warning_level=2'])
 
 cmake = import('cmake')
+cpp = meson.get_compiler('cpp')
 
-absl = cmake.subproject('absl', cmake_options: [
-  '-DCMAKE_CXX_STANDARD=17',
-])
-
-# Note: Unfortunately, meson does not pull in the "dependent" libraries
-# correctly so we have to list them here. If you take a dependency on some
-# addtional absl features, you will probably need to add more `dependency`
-# lines here. This could also be broken on upgrades.
-absl_all = [
+# absl dependencies need to be explicited...
+# It might be possible to use cmake dependencies (e.g. "absl:string"
+# defined in abslTargets.cmake in the future but that does not seem
+# worth the time trying to figure that out.
+absl_libs = [
     # Via Base:
-    absl.dependency('raw_logging_internal'),
+    'raw_logging_internal',
 
     # Via Strings:
-    absl.dependency('int128'),
-    absl.dependency('str_format_internal'),
-    absl.dependency('strings_internal'),
-    absl.dependency('strings'),
+    'int128',
+    'str_format_internal',
+    'strings_internal',
+    'strings'
 ]
 
+absl_deps = []
+if not get_option('unsupported_use_system_absl')
+    absl = cmake.subproject('absl', cmake_options: [
+        '-DCMAKE_CXX_STANDARD=17',
+    ])
+
+    absl_deps = []
+    foreach lib : absl_libs
+        absl_deps += absl.dependency(lib)
+    endforeach
+else
+    # note that the system's absl needs to be compiled for C++17 standard
+    # or final link will fail.
+    foreach lib : absl_libs
+        dep = cpp.find_library('absl_' + lib)
+        if dep.found()
+            absl_deps += dep
+        endif
+    endforeach
+endif
 libmpdclient = dependency('libmpdclient')
 
 sources = files(
     'src/ashuffle.cc',
     'src/load.cc',
-	'src/args.cc',
-	'src/getpass.cc',
-	'src/rule.cc',
+    'src/args.cc',
+    'src/getpass.cc',
+    'src/rule.cc',
     'src/shuffle.cc',
 )
 
@@ -38,55 +55,54 @@ src_inc = include_directories('src')
 root_inc = include_directories('.')
 
 ashuffle = executable(
-	'ashuffle',
-	executable_sources,
-	dependencies: absl_all + [libmpdclient],
-	install: true
+    'ashuffle',
+    executable_sources,
+    dependencies: absl_deps + [libmpdclient],
+    install: true
 )
 
 clang_tidy = run_target('ashuffle-clang-tidy',
     command : files('scripts/run-clang-tidy') + executable_sources
 )
 
-# We only generate tests if we are *not running in tidy mode
 if get_option('tests').enabled()
 
-googletest = cmake.subproject('googletest', cmake_options: [
-  '-DBUILD_GMOCK=ON',
-  '-DCMAKE_CXX_STANDARD=17',
-])
+    googletest = cmake.subproject('googletest', cmake_options: [
+        '-DBUILD_GMOCK=ON',
+        '-DCMAKE_CXX_STANDARD=17',
+    ])
 
-gtest_deps = [
-  dependency('threads'),
-  googletest.dependency('gtest'),
-  googletest.dependency('gmock'),
-  googletest.dependency('gmock_main'),
-]
+    gtest_deps = [
+        dependency('threads'),
+        googletest.dependency('gtest'),
+        googletest.dependency('gmock'),
+        googletest.dependency('gmock_main'),
+    ]
 
-mpdfake_inc = include_directories('t')
-mpdfake_dep = declare_dependency(include_directories : mpdfake_inc)
+    mpdfake_inc = include_directories('t')
+    mpdfake_dep = declare_dependency(include_directories : mpdfake_inc)
 
-test_options = [
-    'werror=true',
-]
+    test_options = [
+        'werror=true',
+    ]
 
-tests = {
-    'rule': ['t/rule_test.cc'],
-    'shuffle': ['t/shuffle_test.cc'],
-    'load': ['t/load_test.cc'],
-    'args': ['t/args_test.cc'],
-    'ashuffle': ['t/ashuffle_test.cc'],
-}
+    tests = {
+        'rule': ['t/rule_test.cc'],
+        'shuffle': ['t/shuffle_test.cc'],
+        'load': ['t/load_test.cc'],
+        'args': ['t/args_test.cc'],
+        'ashuffle': ['t/ashuffle_test.cc'],
+    }
 
-foreach test_name, test_sources : tests
-    test_exe = executable(
-        test_name + '_test',
-        sources + test_sources,
-        include_directories : src_inc,
-        dependencies : absl_all + gtest_deps + [mpdfake_dep],
-        override_options : test_options,
-    )
-    test(test_name, test_exe)
-endforeach
+    foreach test_name, test_sources : tests
+        test_exe = executable(
+            test_name + '_test',
+            sources + test_sources,
+            include_directories : src_inc,
+            dependencies : absl_deps, gtest_deps + [mpdfake_dep],
+            override_options : test_options,
+        )
+        test(test_name, test_exe)
+    endforeach
 
 endif # tests feature

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
-option('tidy_mode', type : 'feature', value : 'disabled')
 option('tests', type : 'feature', value : 'disabled')
+option('unsupported_use_system_absl', type : 'boolean', value : 'false')


### PR DESCRIPTION
I'm pretty sure you won't like this one (at the very least I don't! which means that the packaging work I did for it will likely stay in my tree, oh well...) but I don't see much way around it.
I don't think nixos (the distro I use on my mpd box) would allow using a subproject... I'm pretty sure debian and the likes frown upon that but I'm not sure honestly.

(offtopic rant: It's a shame nixos already has an absl lib but it's built with default c++11 target so not abi-compatible, that took me ages to understand :/)


Anyway, I'm clueless about c++, but it looks like absl really is mostly only used for tests. Would it make sense to have macro conditionals using it or not? That would mean package codes aren't what's actually tested so it's probably a bad idea, but I think it does kind of get in the way of world domination (err I mean #36)
Long story short please close this once you've read this rant :D