### PR TITLE
replace unsigned and int with size_t in appropriate places

### DIFF
--- a/src/ashuffle.cc
+++ b/src/ashuffle.cc
@@ -159,7 +159,7 @@ void Loop(mpd::MPD *mpd, ShuffleChain *songs, const Options &options,
             songs->Clear();
             MPDLoader loader(mpd, options.ruleset);
             loader.Load(songs);
-            printf("Picking random songs out of a pool of %u.\n", songs->Len());
+            printf("Picking random songs out of a pool of %lu.\n", songs->Len());
         } else if (events.Has(MPD_IDLE_QUEUE) || events.Has(MPD_IDLE_PLAYER)) {
             TryEnqueue(mpd, songs, options);
         }

--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -16,12 +16,12 @@ void ShuffleChain::Clear() {
 
 void ShuffleChain::Add(ShuffleItem item) {
     _items.emplace_back(item);
-    _pool.push_back(static_cast<int>(_items.size()) - 1);
+    _pool.push_back(_items.size() - 1);
 }
 
-unsigned ShuffleChain::Len() { return _items.size(); }
-unsigned ShuffleChain::LenURIs() {
-    unsigned sum = 0;
+size_t ShuffleChain::Len() { return _items.size(); }
+size_t ShuffleChain::LenURIs() {
+    size_t sum = 0;
     for (auto& group : _items) {
         sum += group._uris.size();
     }
@@ -32,7 +32,7 @@ unsigned ShuffleChain::LenURIs() {
 void ShuffleChain::FillWindow() {
     while (_window.size() <= _max_window && _pool.size() > 0) {
         /* push a random song from the pool onto the end of the window */
-        unsigned idx = rand() % _pool.size();
+        size_t idx = rand() % _pool.size();
         _window.push_back(_pool[idx]);
         _pool.erase(_pool.begin() + idx);
     }
@@ -41,7 +41,7 @@ void ShuffleChain::FillWindow() {
 const std::vector<std::string>& ShuffleChain::Pick() {
     assert(Len() != 0 && "cannot pick from empty chain");
     FillWindow();
-    int picked_idx = _window[0];
+    size_t picked_idx = _window[0];
     _window.pop_front();
     _pool.push_back(picked_idx);
     return _items[picked_idx]._uris;

--- a/src/shuffle.h
+++ b/src/shuffle.h
@@ -27,7 +27,7 @@ class ShuffleChain {
     ShuffleChain() : ShuffleChain(1){};
 
     // Create a new ShuffleChain with the given window length.
-    ShuffleChain(unsigned window) : _max_window(window){};
+    explicit ShuffleChain(size_t window) : _max_window(window){};
 
     // Clear this shuffle chain, removing anypreviously added songs.
     void Clear();
@@ -37,10 +37,10 @@ class ShuffleChain {
     void Add(ShuffleItem i);
 
     // Return the total number of Items (groups) in this chain.
-    unsigned Len();
+    size_t Len();
 
     // Return the total number of URIs in this chain, in all items.
-    unsigned LenURIs();
+    size_t LenURIs();
 
     // Pick a group of songs out of this chain.
     const std::vector<std::string>& Pick();
@@ -53,10 +53,10 @@ class ShuffleChain {
    private:
     void FillWindow();
 
-    unsigned _max_window;
+    size_t _max_window;
     std::vector<ShuffleItem> _items;
-    std::deque<int> _window;
-    std::deque<int> _pool;
+    std::deque<size_t> _window;
+    std::deque<size_t> _pool;
 };
 
 }  // namespace ashuffle


### PR DESCRIPTION
_pool and _window are used to store indicies of _items and since _items.size() usually returns size_t,
they should store size_t's just to be sure.
unsigned or int may overflow with really, really big databases or if the system has a really small (unsigned) int.

It probably won't ever overflow in the wild (you'd need a few billion songs on most systems),
but theoretically it could and should be made overflow-safe.

See also: https://en.cppreference.com/w/cpp/types/size_t