### PR TITLE
allow use of system gtest

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -71,17 +71,26 @@ clang_tidy = run_target('ashuffle-clang-tidy',
 
 if get_option('tests').enabled()
 
-    googletest = cmake.subproject('googletest', cmake_options: [
-        '-DBUILD_GMOCK=ON',
-        '-DCMAKE_CXX_STANDARD=17',
-    ])
+    if not get_option('unsupported_use_system_gtest')
+      googletest = cmake.subproject('googletest', cmake_options: [
+          '-DBUILD_GMOCK=ON',
+          '-DCMAKE_CXX_STANDARD=17',
+      ])
 
-    gtest_deps = [
+      gtest_deps = [
+          dependency('threads'),
+          googletest.dependency('gtest'),
+          googletest.dependency('gmock'),
+          googletest.dependency('gmock_main'),
+      ]
+    else
+      gtest_deps = [
         dependency('threads'),
-        googletest.dependency('gtest'),
-        googletest.dependency('gmock'),
-        googletest.dependency('gmock_main'),
-    ]
+        dependency('gtest', version: '>=1.10'),
+        dependency('gmock', version: '>=1.10'),
+        dependency('gmock_main', version: '>=1.10'),
+      ]
+    endif
 
     mpdfake_inc = include_directories('t')
     mpdfake_dep = declare_dependency(include_directories : mpdfake_inc)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('tests', type : 'feature', value : 'disabled')
 option('unsupported_use_system_absl', type : 'boolean', value : 'false')
+option('unsupported_use_system_gtest', type : 'boolean', value : 'false')


### PR DESCRIPTION
Rationale:
* Package Maintainers can package gtest and ashuffle separately if policies or other things require it
* You don't have to download gtest multiple times or have multiple copies of it in 5 different projects, if it's installed system-wide
   (usually also a rationale of package maintainers, and my personal reason for this as I dislike duplicates on my filesystem)

Comments:
* Since INSTANTIATE_TEST_SUITE_P is not present in gtest 1.8, I chose to require 1.10 or later.
* Same reasoning for the `unsupported_use_system_` prefix as the abseil one, it tells people who's at fault if it breaks. :sunglasses:  