### PR TITLE
RFC: change the prng from c rand() to std::mt19937

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -112,9 +112,6 @@ int main(int argc, const char* argv[]) {
                   << "." << std::endl;
     }
 
-    /* Seed the random number generator */
-    srand(time(NULL));
-
     /* do the main action */
     if (options.queue_only) {
         for (unsigned i = 0; i < options.queue_only; i++) {

--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <numeric>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -31,8 +32,9 @@ size_t ShuffleChain::LenURIs() {
 /* ensure that our window is as full as it can possibly be. */
 void ShuffleChain::FillWindow() {
     while (_window.size() <= _max_window && _pool.size() > 0) {
+        std::uniform_int_distribution<unsigned long long> rd{0, _pool.size() - 1};
         /* push a random song from the pool onto the end of the window */
-        size_t idx = rand() % _pool.size();
+        size_t idx = rd(_rng);
         _window.push_back(_pool[idx]);
         _pool.erase(_pool.begin() + idx);
     }

--- a/src/shuffle.h
+++ b/src/shuffle.h
@@ -2,6 +2,7 @@
 #define __ASHUFFLE_SHUFFLE_H__
 
 #include <deque>
+#include <random>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -27,7 +28,15 @@ class ShuffleChain {
     ShuffleChain() : ShuffleChain(1){};
 
     // Create a new ShuffleChain with the given window length.
-    explicit ShuffleChain(size_t window) : _max_window(window){};
+    explicit ShuffleChain(size_t window) : _max_window(window) {
+        std::random_device rd;
+        _rng.seed(rd());
+    }
+
+    // Create a new ShuffleChain with the given window length
+    // and using the given RandomNumberEngine
+    ShuffleChain(size_t window, std::mt19937 rng)
+        : _max_window(window), _rng(rng) {}
 
     // Clear this shuffle chain, removing anypreviously added songs.
     void Clear();
@@ -57,6 +66,7 @@ class ShuffleChain {
     std::vector<ShuffleItem> _items;
     std::deque<size_t> _window;
     std::deque<size_t> _pool;
+    std::mt19937 _rng;
 };
 
 }  // namespace ashuffle

--- a/t/shuffle_test.cc
+++ b/t/shuffle_test.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include <random>
 
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
@@ -115,15 +116,15 @@ INSTANTIATE_TEST_SUITE_P(BigWindows, WindowTest, Values(50, 99, 100, 1000));
 //  how we index the song list when picking randomly. It's hard to test
 //  that something is random :/.
 TEST(ShuffleChainTest, IsRandom) {
-    srand(4);
+    std::mt19937 rnd_engine(4);
 
-    ShuffleChain chain(2);
+    ShuffleChain chain(2, rnd_engine);
 
     chain.Add("test a");
     chain.Add("test b");
     chain.Add("test c");
 
-    std::vector<std::string> want{"test b", "test c", "test a", "test b"};
+    std::vector<std::string> want{ "test c", "test b", "test a", "test c" };
     std::vector<std::string> got;
     for (int i = 0; i < 4; i++) {
         auto pick = chain.Pick();


### PR DESCRIPTION
This one's more of a cautious proposal or "request for comments", since it touches the very core feature of ashuffle.
But since the switch from C to modern C++, it makes sense to take a look at or even use the features C++17 offers.
This would be one of them.

Rationale:
 * C rand() is usually implemented using a linear congruential engine,
   the actual implementation may vary though depending on stdlib/compiler
   vendor because there's no strong quality requirement.
   Some rand() implementations thus may have poor quality. [3][1]
 * C rand() is limited by RAND_MAX, which is only guaranteed to be at
   least 32767, if a _pool gets bigger it may ignore some of it on some
   systems with a poor rand() implementation. [4] Like MSVC. [5]
   (My personal library has 28978 songs, so it is probably not unreasonable to assume someone may reach 32767)
 * C++ engines and distributions in <random> give more quality
   guarantees and should be of mostly uniform quality across different
   STL vendors. The Mersenne twister has the highest quality of random
   numbers of the offered engines, according to [2].
   One can also choose how random numbers are statistically distributed,
   if desired. Uniform distribution should be good enough for this, I believe.

[1]: https://en.cppreference.com/w/c/numeric/random/rand
[2]: https://en.cppreference.com/w/cpp/numeric/random
[3]: https://en.cppreference.com/w/cpp/numeric/random/rand
[4]: https://en.cppreference.com/w/c/numeric/random/RAND_MAX
[5]: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rand?view=vs-2019


I've ran a build of ashuffle with this patch about 12h with no obvious problems, but problems in randomness are seldom easy to see... [citation needed] :smile: 