### PR TITLE
Add arm32 releases to ashuffle

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,16 +256,34 @@ please open an issue.
 
 # getting ashuffle
 
+ashuffle is officially distributed via pre-compiled binaries, and via its
+source. Linux-compatible binaries are currently available for `x86_64`,
+and several ARM flavors that should support most ARM users, including
+Raspberry Pi.
+
 ## pre-built binaries
 
-ashuffle is officially distributed via pre-compiled binaries, and via its
-source. Binaries are currently available for `x86_64`, and `aarch64`
-(cortex-a53+, including Raspberry Pi3+) targets running linux. You can
-download the latest binary for your platform [on the releases page](
-https://github.com/joshkunz/ashuffle/releases).
+First, install 'libmpdclient', the library ashuffle uses to interact with MPD.
+It can be obtained from most package managers. E.g. via `sudo apt install
+libmpdclient2`, or `brew install libmpdclient`. Once libmpdclient is installed
+you can download the latest binary release for your platform [on the releases
+page](https://github.com/joshkunz/ashuffle/releases). Binaries are currently
+available for the following platforms:
 
-If you'd like to add binary support to another platform, pull requests are
-welcome.
+| Binary | Architecture | Minimum CPU | Popular Devices |
+| ------ | ------------ | ----------- | --------------- |
+| `ashuffle.x86_64-linux-gnu` | `x86_64` |||
+| `ashuffle.aarch64-linux-gnu` | `aarch64` | `cortex-a53` | Raspberry Pi 3B+ running 64-bit OS (not RPi OS) |
+| `ashuffle.armv7h-linux-gnueabihf` | `armv7hl` | `cortex-a7` | Raspberry Pi 2B+ Running RPi OS (f.k.a. Raspbian) |
+| `ashuffle.armv6h-linux-gnueabihf` | `armv6hl` | `arm1176jzf-s` | Raspberry Pi 0/1 |
+
+Once you've downloaded the binary, it should "just work" when run
+(e.g. `$ ./ashuffle.x86_64-linux-gnu`). If they do not, please [file an
+issue](https://github.com/joshkunz/ashuffle/issues) or send an email to the
+ashuffle users list at `users@ashuffle.app`.
+
+If you'd like to add binary support to another platform, pull
+requests are welcome.
 
 ## installing from source
 

--- a/scripts/travis/release
+++ b/scripts/travis/release
@@ -6,3 +6,5 @@ setup
 mkdir -p release
 tools/meta/meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
 tools/meta/meta release -o release/ashuffle.aarch64-linux-gnu aarch64 || die "couldn't build aarch64"
+tools/meta/meta release -o release/ashuffle.armv7h-linux-gnueabihf armv7h|| die "couldn't build armv7h"
+tools/meta/meta release -o release/ashuffle.armv6h-linux-gnueabihf armv6h|| die "couldn't build armv6h"

--- a/src/ashuffle.cc
+++ b/src/ashuffle.cc
@@ -159,7 +159,8 @@ void Loop(mpd::MPD *mpd, ShuffleChain *songs, const Options &options,
             songs->Clear();
             MPDLoader loader(mpd, options.ruleset);
             loader.Load(songs);
-            printf("Picking random songs out of a pool of %lu.\n", songs->Len());
+            std::cout << "Picking random songs out of a pool of "
+                      << songs->Len() << "." << std::endl;
         } else if (events.Has(MPD_IDLE_QUEUE) || events.Has(MPD_IDLE_PLAYER)) {
             TryEnqueue(mpd, songs, options);
         }

--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -32,7 +32,8 @@ size_t ShuffleChain::LenURIs() {
 /* ensure that our window is as full as it can possibly be. */
 void ShuffleChain::FillWindow() {
     while (_window.size() <= _max_window && _pool.size() > 0) {
-        std::uniform_int_distribution<unsigned long long> rd{0, _pool.size() - 1};
+        std::uniform_int_distribution<unsigned long long> rd{0,
+                                                             _pool.size() - 1};
         /* push a random song from the pool onto the end of the window */
         size_t idx = rd(_rng);
         _window.push_back(_pool[idx]);

--- a/t/shuffle_test.cc
+++ b/t/shuffle_test.cc
@@ -2,10 +2,10 @@
 
 #include <stdlib.h>
 #include <algorithm>
+#include <random>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <random>
 
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
@@ -124,7 +124,7 @@ TEST(ShuffleChainTest, IsRandom) {
     chain.Add("test b");
     chain.Add("test c");
 
-    std::vector<std::string> want{ "test c", "test b", "test a", "test c" };
+    std::vector<std::string> want{"test c", "test b", "test a", "test c"};
     std::vector<std::string> got;
     for (int i = 0; i < 4; i++) {
         auto pick = chain.Pick();


### PR DESCRIPTION
This PR should address #66. It adds `armv6h` and `armv7h` releases as mentioned by @gearhead (thanks!).