### PR TITLE
Mark end of Parser::ConsumeInternal unreachable.

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -299,6 +299,7 @@ std::variant<Parser::State, ParseError> Parser::ConsumeInternal(
             return ParseError(absl::StrFormat("bad option '%s'", arg));
     }
     assert(false && "unreachable, invalid state");
+    __builtin_unreachable();
 }
 
 }  // namespace


### PR DESCRIPTION
Hopefully this will avoid `-Wreturn-type` errors.