### PR TITLE
Add `--tweak`s for advanced configuration options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,10 +143,31 @@ It's equivalent to `--group-by album date`.
 
 Note that `-g`/`--group-by`/`--by-album` can only be provided once.
 
+### advanced options for specialized preferences, with `--tweak`
+
+Tweaks are infrequently used, specialized, or complicated options that most
+users probably don't want to use. These options are all set via a single
+`--tweak`/`-t` flag to avoid cluttering help pages. All tweaks have the form
+`<key>=<value>`. For example: `--tweak window-size=7`. Here is a table of
+tweaks, and their meanings:
+
+| Name | Values | Default | Description |
+| ---- | ------ | ------- | ----------- |
+| `window-size` | Integer `>=1` | `7` | Sets the size of the "window" used for the shuffle algorithm. See the section on the [shuffle algorithm](#shuffle-algorithm) for more details. In-short: Lower numbers mean more frequent repeats, and higher numbers mean less frequent repeats. |
+| `play-on-startup` | Boolean | `yes` | If set to a true value, ashuffle starts playing music if MPD is paused, stopped, or the queue is empty on startup. If set to false, then ashuffle will not enqueue any music until a song is enqueued for the first time. |
+
+Value types:
+
+| Name | Representation |
+| ---- | -------------- |
+| Integer | An integral number, like `-1`, `0`, or `15`. |
+| Boolean | The strings `on`, `true`, `yes` or `1` mean "true" or "enable", and the strings `off`, `false`, `no`, or `0` mean "false" or "disable". |
+
 ## help text
 
 ```
-usage: ashuffle [-h] [-n] [-e PATTERN ...] [-o NUMBER] [-f FILENAME] [-q NUMBER] [-g TAG ...]
+usage: ashuffle [-h] [-n] [[-e PATTERN ...] ...] [-o NUMBER] [-f FILENAME] [-q NUMBER]
+    [-g TAG ...] [[-t TWEAK] ...]
 
 Optional Arguments:
    -h,-?,--help      Display this help message.
@@ -176,6 +197,8 @@ Optional Arguments:
                      the currently playing song. This is to support MPD
                      features like crossfade that don't work if there
                      are no more songs in the queue.
+   -t,--tweak        Tweak an infrequently used ashuffle option. See
+                     `readme.md` for a list of available options.
 See included `readme.md` file for PATTERN syntax.
 ```
 

--- a/src/args.cc
+++ b/src/args.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <fstream>
 #include <iostream>
@@ -52,6 +53,20 @@ constexpr char kHelpMessage[] =
     "   -t,--tweak        Tweak an infrequently used ashuffle option. See\n"
     "                     `readme.md` for a list of available options.\n"
     "See included `readme.md` file for PATTERN syntax.\n";
+
+// Parse the given string as a boolean. Produces an empty option if no value
+// can be parsed.
+std::optional<bool> ParseBool(std::string val) {
+    std::transform(val.begin(), val.end(), val.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (val == "yes" || val == "true" || val == "on" || val == "1") {
+        return true;
+    }
+    if (val == "no" || val == "false" || val == "off" || val == "0") {
+        return false;
+    }
+    return std::nullopt;
+}
 
 class Parser {
    public:
@@ -214,6 +229,16 @@ std::variant<Parser::State, ParseError> Parser::ParseTweak(
             return ParseError(absl::StrFormat(
                 "tweak window-size must be >= 1 (%s given)", value));
         }
+        return kNone;
+    }
+
+    if (key == "play-on-startup") {
+        auto v = ParseBool(value);
+        if (!v) {
+            return ParseError(absl::StrFormat(
+                "play-on-startup must be a boolean value ('%s' given)", value));
+        }
+        opts_.tweak.play_on_startup = *v;
         return kNone;
     }
 

--- a/src/args.h
+++ b/src/args.h
@@ -40,6 +40,11 @@ class Options {
     struct {
         bool print_all_songs_and_exit = false;
     } test = {};
+    // Minor "tweak" options that are not part of the main options.
+    struct {
+        // Window size to use for the global shuffle chain.
+        int window_size = 7;
+    } tweak = {};
     std::vector<enum mpd_tag_type> group_by = {};
 
     // Parse parses the arguments in the given vector and returns ParseResult
@@ -78,6 +83,9 @@ class Options {
 // Print the help message on the given output stream, and return the input
 // ostream.
 std::ostream &DisplayHelp(std::ostream &);
+
+// Print the given ParseError to the given output stream.
+std::ostream &operator<<(std::ostream &out, const ParseError &e);
 
 }  // namespace ashuffle
 

--- a/src/args.h
+++ b/src/args.h
@@ -44,6 +44,10 @@ class Options {
     struct {
         // Window size to use for the global shuffle chain.
         int window_size = 7;
+        // If true, start playing music when ashuffle is first started.
+        // Otherwise, ashuffle will wait for an MPD event before playing
+        // music.
+        bool play_on_startup = true;
     } tweak = {};
     std::vector<enum mpd_tag_type> group_by = {};
 

--- a/src/ashuffle.cc
+++ b/src/ashuffle.cc
@@ -144,7 +144,7 @@ void Loop(mpd::MPD *mpd, ShuffleChain *songs, const Options &options,
 
     // If the test delegate's `skip_init` is set to true, then skip the
     // initializer.
-    if (!test_d.skip_init) {
+    if (options.tweak.play_on_startup) {
         TryFirst(mpd, songs);
         TryEnqueue(mpd, songs, options);
     }

--- a/src/ashuffle.h
+++ b/src/ashuffle.h
@@ -23,7 +23,6 @@ std::unique_ptr<mpd::MPD> Connect(const mpd::Dialer& d, const Options& options,
                                   std::function<std::string()>& getpass_f);
 
 struct TestDelegate {
-    bool skip_init = false;
     bool (*until_f)() = nullptr;
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,9 +20,6 @@ using namespace ashuffle;
 
 namespace {
 
-// The size of the rolling shuffle window.
-const int kWindowSize = 7;
-
 std::unique_ptr<Loader> BuildLoader(mpd::MPD* mpd, const Options& opts) {
     if (opts.file_in != nullptr && opts.check_uris) {
         return std::make_unique<FileMPDLoader>(mpd, opts.ruleset, opts.group_by,
@@ -73,7 +70,7 @@ int main(int argc, const char* argv[]) {
     std::unique_ptr<mpd::MPD> mpd =
         Connect(*mpd::client::Dialer(), options, pass_f);
 
-    ShuffleChain songs(kWindowSize);
+    ShuffleChain songs((size_t)options.tweak.window_size);
 
     {
         // We construct the loader in a new scope, since loaders can

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -42,6 +42,7 @@ TEST(ParseTest, Empty) {
     EXPECT_EQ(opts.port, 0U);
     EXPECT_FALSE(opts.test.print_all_songs_and_exit);
     EXPECT_TRUE(opts.group_by.empty());
+    EXPECT_EQ(opts.tweak.window_size, 7);
 }
 
 TEST(ParseTest, Short) {
@@ -50,7 +51,7 @@ TEST(ParseTest, Short) {
     });
 
     // clang-format off
-    Options opts = std::get<Options>(Options::Parse(tagger, {
+    auto result = Options::Parse(tagger, {
         "-o", "5",
         "-n",
         "-q", "10",
@@ -58,8 +59,14 @@ TEST(ParseTest, Short) {
         "-f", "/dev/zero",
         "-p", "1234",
         "-g", "artist",
-    }));
+        "-t", "window-size=3",
+    });
     // clang-format on
+
+    ASSERT_EQ(std::get_if<ParseError>(&result), nullptr)
+        << std::get<ParseError>(result);
+
+    Options opts = std::move(std::get<Options>(result));
 
     EXPECT_EQ(opts.ruleset.size(), 2U);
     EXPECT_EQ(opts.queue_only, 5U);
@@ -68,6 +75,7 @@ TEST(ParseTest, Short) {
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.port, 1234U);
     EXPECT_THAT(opts.group_by, ElementsAre(MPD_TAG_ARTIST));
+    EXPECT_EQ(opts.tweak.window_size, 3);
 }
 
 TEST(ParseTest, Long) {
@@ -76,8 +84,7 @@ TEST(ParseTest, Long) {
     });
 
     // clang-format off
-    Options opts =
-        std::get<Options>(Options::Parse(tagger, {
+    auto result = Options::Parse(tagger, {
             "--only", "5",
             "--no-check",
             "--file", "/dev/zero",
@@ -86,8 +93,14 @@ TEST(ParseTest, Long) {
             "--host", "foo",
             "--port", "1234",
             "--group-by", "artist",
-    }));
+            "--tweak", "window-size=5",
+    });
     // clang-format on
+
+    ASSERT_EQ(std::get_if<ParseError>(&result), nullptr)
+        << std::get<ParseError>(result);
+
+    Options opts = std::move(std::get<Options>(result));
 
     EXPECT_EQ(opts.ruleset.size(), 2U);
     EXPECT_EQ(opts.queue_only, 5U);
@@ -97,6 +110,7 @@ TEST(ParseTest, Long) {
     EXPECT_EQ(opts.host, "foo");
     EXPECT_EQ(opts.port, 1234U);
     EXPECT_THAT(opts.group_by, ElementsAre(MPD_TAG_ARTIST));
+    EXPECT_EQ(opts.tweak.window_size, 5);
 }
 
 TEST(ParseTest, MixedLongShort) {
@@ -226,6 +240,11 @@ std::vector<ParseFailureParam> partial_cases = {
      HasSubstr("'-g' can only be provided once")},
     {{"--by-album", "-g", "artist"},
      HasSubstr("'-g' can only be provided once")},
+    {{"--tweak"}, HasSubstr("no argument supplied for '--tweak'")},
+    {{"--tweak", "window-size", "fail"},
+     HasSubstr("tweak must be of the form <name>=<value>")},
+    {{"--tweak", "window-size="},
+     HasSubstr("tweak must be of the form <name>=<value>")},
 };
 
 INSTANTIATE_TEST_SUITE_P(Partials, ParseFailureTest, ValuesIn(partial_cases));
@@ -233,9 +252,21 @@ INSTANTIATE_TEST_SUITE_P(Partials, ParseFailureTest, ValuesIn(partial_cases));
 std::vector<ParseFailureParam> strtou_cases = {
     {{"--only", "0x5.0"}, MatchesRegex("couldn't convert .* '0x5\\.0'")},
     {{"--queue-buffer", "20U"}, MatchesRegex("couldn't convert .* '20U'")},
+    {{"--tweak", "window-size=20=x"},
+     MatchesRegex("couldn't convert .* '20=x'")},
 };
 
 INSTANTIATE_TEST_SUITE_P(BadStrtou, ParseFailureTest, ValuesIn(strtou_cases));
+
+std::vector<ParseFailureParam> constraint_cases = {
+    {{"--tweak", "window-size=0"},
+     HasSubstr("window-size must be >= 1 (0 given)")},
+    {{"--tweak", "window-size=-2"},
+     HasSubstr("window-size must be >= 1 (-2 given)")},
+};
+
+INSTANTIATE_TEST_SUITE_P(Constraint, ParseFailureTest,
+                         ValuesIn(constraint_cases));
 
 TEST(ParseTest, TestOption) {
     fake::TagParser tagger;

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -43,6 +43,7 @@ TEST(ParseTest, Empty) {
     EXPECT_FALSE(opts.test.print_all_songs_and_exit);
     EXPECT_TRUE(opts.group_by.empty());
     EXPECT_EQ(opts.tweak.window_size, 7);
+    EXPECT_EQ(opts.tweak.play_on_startup, true);
 }
 
 TEST(ParseTest, Short) {
@@ -179,6 +180,20 @@ TEST(ParseTest, ByAlbum) {
         << "--by-album should be equivalent to --group-by album date";
 }
 
+TEST(ParseTest, TweakPlayOnStartup) {
+    std::vector<std::tuple<std::string, bool>> cases = {
+        {"on", true},   {"true", true}, {"yes", true},    {"1", true},
+        {"True", true}, {"yEs", true},  {"off", false},   {"false", false},
+        {"no", false},  {"0", false},   {"False", false}, {"nO", false},
+    };
+
+    for (auto [val, want] : cases) {
+        Options opts = std::get<Options>(Options::Parse(
+            fake::TagParser(), {"--tweak", "play-on-startup=" + val}));
+        EXPECT_EQ(opts.tweak.play_on_startup, want) << "Case: " << val;
+    }
+}
+
 using ParseFailureParam =
     std::tuple<std::vector<std::string>, Matcher<std::string>>;
 
@@ -245,6 +260,8 @@ std::vector<ParseFailureParam> partial_cases = {
      HasSubstr("tweak must be of the form <name>=<value>")},
     {{"--tweak", "window-size="},
      HasSubstr("tweak must be of the form <name>=<value>")},
+    {{"--tweak", "play-on-startup="},
+     HasSubstr("tweak must be of the form <name>=<value>")},
 };
 
 INSTANTIATE_TEST_SUITE_P(Partials, ParseFailureTest, ValuesIn(partial_cases));
@@ -263,6 +280,8 @@ std::vector<ParseFailureParam> constraint_cases = {
      HasSubstr("window-size must be >= 1 (0 given)")},
     {{"--tweak", "window-size=-2"},
      HasSubstr("window-size must be >= 1 (-2 given)")},
+    {{"--tweak", "play-on-startup=2"},
+     HasSubstr("play-on-startup must be a boolean value ('2' given)")},
 };
 
 INSTANTIATE_TEST_SUITE_P(Constraint, ParseFailureTest,

--- a/t/ashuffle_test.cc
+++ b/t/ashuffle_test.cc
@@ -60,14 +60,12 @@ void xclearenv() {
 // This test delegate only allows the "init" part of the loop to run. No
 // continous logic runs.
 TestDelegate init_only_d = {
-    .skip_init = false,
     .until_f = [] { return false; },
 };
 
 // This delegate *only* runs the core loop logic, and it only runs the
 // logic once.
 TestDelegate loop_once_d{
-    .skip_init = true,
     .until_f =
         [] {
             static unsigned count;
@@ -144,6 +142,8 @@ TEST_F(LoopTest, InitWhileStopped) {
 }
 
 TEST_F(LoopTest, Requeue) {
+    opts.tweak.play_on_startup = false;
+
     // Pretend like we already have a song in our queue, that was playing,
     // but now we've stopped.
     mpd.queue.push_back(song_b);
@@ -162,6 +162,8 @@ TEST_F(LoopTest, Requeue) {
 }
 
 TEST_F(LoopTest, RequeueEmpty) {
+    opts.tweak.play_on_startup = false;
+
     // Leaving the MPD queue empty.
 
     Loop(&mpd, &chain, opts, loop_once_d);
@@ -174,6 +176,7 @@ TEST_F(LoopTest, RequeueEmpty) {
 }
 
 TEST_F(LoopTest, RequeueEmptyWithQueueBuffer) {
+    opts.tweak.play_on_startup = false;
     opts.queue_buffer = 3;
 
     Loop(&mpd, &chain, opts, loop_once_d);
@@ -190,6 +193,7 @@ TEST_F(LoopTest, RequeueEmptyWithQueueBuffer) {
 }
 
 TEST_F(LoopTest, RequeueWithQueueBufferPartiallyFilled) {
+    opts.tweak.play_on_startup = false;
     opts.queue_buffer = 3;
 
     // Make future IDLE calls return IDLE_QUEUE for this test.
@@ -220,6 +224,7 @@ TEST_F(LoopTest, RequeueWithQueueBufferPartiallyFilled) {
 // Test that when we have a partially filled queue buffer, and we have groups
 // of songs, we re-queue just enough songs to fill the buffer.
 TEST_F(LoopTest, RequeueWithQueueBufferPartiallyFilledAndGrouping) {
+    opts.tweak.play_on_startup = false;
     opts.queue_buffer = 4;
 
     // Make future IDLE calls return IDLE_QUEUE for this test.


### PR DESCRIPTION
This change series adds the `--tweak` option, with two tweaks `window-size`, and `play-on-startup`, as well as documentation and tests. These tweaks should address feature requests in issues #72 and #67. 