### PR TITLE
Tweak output when using --only

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -113,13 +113,14 @@ int main(int argc, const char* argv[]) {
     if (options.queue_only) {
         size_t number_of_songs{};
         for (unsigned i = 0; i < options.queue_only; i++) {
-            auto &picked_songs = songs.Pick();
+            auto& picked_songs = songs.Pick();
             number_of_songs += picked_songs.size();
             mpd->Add(picked_songs);
         }
 
         /* print number of songs or groups (and songs) added */
-        std::cout << absl::StrFormat("Added %u %s%s", options.queue_only,
+        std::cout << absl::StrFormat(
+            "Added %u %s%s", options.queue_only,
             options.group_by.empty() ? "song" : "group",
             options.queue_only > 1 ? "s" : "");
         if (!options.group_by.empty()) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -111,10 +111,22 @@ int main(int argc, const char* argv[]) {
 
     /* do the main action */
     if (options.queue_only) {
+        size_t number_of_songs{};
         for (unsigned i = 0; i < options.queue_only; i++) {
-            mpd->Add(songs.Pick());
+            auto &picked_songs = songs.Pick();
+            number_of_songs += picked_songs.size();
+            mpd->Add(picked_songs);
         }
-        std::cout << "Added " << options.queue_only << " songs." << std::endl;
+
+        /* print number of songs or groups (and songs) added */
+        std::cout << absl::StrFormat("Added %u %s%s", options.queue_only,
+            options.group_by.empty() ? "song" : "group",
+            options.queue_only > 1 ? "s" : "");
+        if (!options.group_by.empty()) {
+            std::cout << absl::StrFormat(" (%u songs)", number_of_songs);
+        }
+        std::cout << "." << std::endl;
+
     } else {
         Loop(mpd.get(), &songs, options);
     }


### PR DESCRIPTION
This commit tweaks the message presented to the user when --only is
used. Previously the message didn't differentiate between songs and
groups and always added a plural s. Messages for the newly added cases
look like this:

$ ashuffle --only 1
Picking random songs out of a pool of 14008.
Added 1 song.

$ ashuffle --by-album --only 1
Picking from 1086 groups (14008 songs).
Added 1 group (12 songs).

$ ashuffle --by-album --only 3
Picking from 1086 groups (14008 songs).
Added 3 groups (34 songs).