### PR TITLE
Re-add Raspberry Pi Zero support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,9 +297,10 @@ available for the following platforms:
 
 | Binary | Architecture | Minimum CPU | Popular Devices |
 | ------ | ------------ | ----------- | --------------- |
-| `ashuffle.x86_64-linux-gnu` | `x86_64` |||
+| `ashuffle.x86_64-linux-gnu` | `x86_64` || Most Desktops, Laptops, and Servers |
 | `ashuffle.aarch64-linux-gnu` | `aarch64` | `cortex-a53` | Raspberry Pi 3B+ running 64-bit OS (not RPi OS) |
 | `ashuffle.armv7h-linux-gnueabihf` | `armv7hl` | `cortex-a7` | Raspberry Pi 2B+ Running RPi OS (f.k.a. Raspbian) |
+| `ashuffle.armv6h-linux-gnueabihf` | `armv6hl` | `arm1176jzf-s` | Raspberry Pi 0/1+ Running RPi OS (f.k.a. Raspbian) |
 
 Once you've downloaded the binary, it should "just work" when run
 (e.g. `$ ./ashuffle.x86_64-linux-gnu`). If they do not, please [file an

--- a/scripts/travis/common.sh
+++ b/scripts/travis/common.sh
@@ -24,10 +24,11 @@ setup() {
     sudo env DEBIAN_FRONTEND=noninteractive apt-get update -y && \
         sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
             clang-9 \
-            clang-tidy-9 \
             clang-format-9 \
+            clang-tidy-9 \
             cmake \
             libmpdclient-dev \
+            lld-9 \
             ninja-build \
             patchelf \
             python3 python3-pip python3-setuptools python3-wheel \

--- a/scripts/travis/release
+++ b/scripts/travis/release
@@ -5,5 +5,9 @@
 setup
 mkdir -p release
 tools/meta/meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
-tools/meta/meta release -o release/ashuffle.aarch64-linux-gnu aarch64 || die "couldn't build aarch64"
-tools/meta/meta release -o release/ashuffle.armv7h-linux-gnueabihf armv7h|| die "couldn't build armv7h"
+tools/meta/meta release -o release/ashuffle.aarch64-linux-gnu \
+    --cross_cc=clang-9 --cross_cxx=clang++-9 aarch64 || die "couldn't build aarch64"
+tools/meta/meta release -o release/ashuffle.armv7h-linux-gnueabihf \
+    --cross_cc=clang-9 --cross_cxx=clang++-9 armv7h || die "couldn't build armv7h"
+tools/meta/meta release -o release/ashuffle.armv6h-linux-gnueabihf \
+    --cross_cc=clang-9 --cross_cxx=clang++-9 armv6h || die "couldn't build armv6h"

--- a/tools/meta/commands/release/release.go
+++ b/tools/meta/commands/release/release.go
@@ -5,202 +5,24 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/urfave/cli/v2"
 
-	"meta/exec"
-	"meta/fetch"
+	"meta/crosstool"
 	"meta/fileutil"
 	"meta/project"
 	"meta/workspace"
 )
 
-var (
-	// Both crosstools obtained from the offical ARM crosstool release:
-	//	https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads
-	// Current Version: 9.2-2019.12
-	aarch64CrosstoolArchive = remoteArchive{
-		URL:    "https://storage.googleapis.com/ashuffle-data/gcc-arm.tar.xz",
-		SHA256: "8dfe681531f0bd04fb9c53cf3c0a3368c616aa85d48938eebe2b516376e06a66",
-	}
-	armCrosstoolArchive = remoteArchive{
-		URL:    "https://storage.googleapis.com/ashuffle-data/gcc-arm32.tar.xz",
-		SHA256: "51bbaf22a4d3e7a393264c4ef1e45566701c516274dde19c4892c911caa85617",
-	}
-
-	aarch64Triple = triple{
-		Architecture: "aarch64",
-		Vendor:       "none",
-		System:       "linux",
-		ABI:          "gnu",
-	}
-
-	armTriple = triple{
-		Architecture: "arm",
-		Vendor:       "none",
-		System:       "linux",
-		ABI:          "gnueabihf",
-	}
-)
-
-type remoteArchive struct {
-	URL    string
-	SHA256 string
-}
-
-func (r remoteArchive) FetchTo(dest string) error {
-	d, err := filepath.Abs(dest)
-	if err != nil {
-		return err
-	}
-
-	ws, err := workspace.New()
-	if err != nil {
-		return err
-	}
-	defer ws.Cleanup()
-
-	if err := fetch.URL(r.URL, ws.Path("archive.tar.xz")); err != nil {
-		return err
-	}
-
-	if err := fileutil.Verify(ws.Path("archive.tar.xz"), r.SHA256); err != nil {
-		return fmt.Errorf("failed to verify: %w", err)
-	}
-
-	untar := exec.Command("tar", "--strip-components=1", "-C", d, "-xJf", ws.Path("archive.tar.xz"))
-	if err := untar.Run(); err != nil {
-		return fmt.Errorf("failed to unpack: %w", err)
-	}
-
-	return nil
-}
-
-type triple struct {
-	Architecture string
-	Vendor       string
-	System       string
-	ABI          string
-}
-
-func (t triple) String() string {
-	return strings.Join([]string{
-		t.Architecture,
-		t.Vendor,
-		t.System,
-		t.ABI,
-	}, "-")
-}
-
-type armCrosstool struct {
-	PkgConfig string
-	CMake     string
-	Triple    triple
-
-	*workspace.Workspace
-}
-
-func newARMCrosstool(triple triple) (*armCrosstool, error) {
-	pkgConfig, err := osexec.LookPath("pkg-config")
-	if err != nil {
-		return nil, fmt.Errorf("unable to find pkg-config: %w", err)
-	}
-	cmake, err := osexec.LookPath("cmake")
-	if err != nil {
-		return nil, fmt.Errorf("unable to find cmake: %w", err)
-	}
-
-	var archive remoteArchive
-	switch triple.Architecture {
-	case "aarch64":
-		archive = aarch64CrosstoolArchive
-	case "arm":
-		archive = armCrosstoolArchive
-	default:
-		return nil, fmt.Errorf("unrecognized architecture %q in triple: %s", triple.Architecture, triple)
-	}
-
-	ws, err := workspace.New(workspace.NoCD)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := archive.FetchTo(ws.Root); err != nil {
-		ws.Cleanup()
-		return nil, err
-	}
-
-	return &armCrosstool{
-		PkgConfig: pkgConfig,
-		CMake:     cmake,
-		Triple:    triple,
-		Workspace: ws,
-	}, nil
-}
-
-var armCrossfileTmpl = template.Must(
-	template.New("arm-crossfile").
-		Funcs(map[string]interface{}{
-			"joinBy": func(delim string, strs []string) string {
-				return strings.Join(strs, delim)
-			},
-		}).
-		Parse(strings.Join([]string{
-			"[binaries]",
-			"c = '{{ .Crosstool.Root }}/bin/{{ .Crosstool.Triple }}-gcc'",
-			"cpp = '{{ .Crosstool.Root }}/bin/{{ .Crosstool.Triple }}-g++'",
-			"c_ld = 'gold'",
-			"cpp_ld = 'gold'",
-			// We have to set pkgconfig and cmake explicitly here, otherwise
-			// meson will not be able to find them. We just re-use the
-			// system versions, since we don't need any special arch-specific
-			// handing.
-			"pkgconfig = '{{ .Crosstool.PkgConfig }}'",
-			"cmake = '{{ .Crosstool.CMake }}'",
-			"",
-			"[properties]",
-			"sys_root = '{{ .Crosstool.Root }}'",
-			"c_args = '-mcpu={{ .CPU }} -I{{ .Crosstool.Root }}/include {{ .CFlags | joinBy \" \" }}'",
-			"c_link_args = '-L{{ .Crosstool.Root }}/lib'",
-			"cpp_args = '-mcpu={{ .CPU }} -I{{ .Crosstool.Root }}/include {{ .CFlags | joinBy \" \" }}'",
-			"cpp_link_args = '-L{{ .Crosstool.Root }}/lib'",
-			"",
-			"[host_machine]",
-			"system = '{{ .Crosstool.Triple.System }}'",
-			"cpu_family = '{{ .Crosstool.Triple.Architecture }}'",
-			"cpu = '{{ .CPU }}'",
-			"endian = 'little'",
-		}, "\n")),
-)
-
-func crossFile(crosstool *armCrosstool, cpu string) (string, error) {
-
-	cf, err := ioutil.TempFile("", "cross-"+crosstool.Triple.Architecture+"-*.txt")
+func crossFile(crosstool *crosstool.Crosstool) (string, error) {
+	cf, err := ioutil.TempFile("", "cross-"+crosstool.CPU.Triple().Architecture+"-*.txt")
 	if err != nil {
 		return "", err
 	}
 
-	info := struct {
-		Crosstool *armCrosstool
-		CPU       string
-		// Flags added to all compiler invocations (C or CXX).
-		CFlags []string
-	}{
-		Crosstool: crosstool,
-		CPU:       cpu,
-	}
-
-	if crosstool.Triple.Architecture == "arm" {
-		// When building for arm32, GCC defaults to THUMB output for
-		// some reason. Force it to output ARM instead.
-		info.CFlags = append(info.CFlags, "-marm")
-	}
-
-	if err := armCrossfileTmpl.Execute(cf, info); err != nil {
+	if err := crosstool.WriteCrossFile(cf); err != nil {
 		cf.Close()
 		os.Remove(cf.Name())
 		return "", err
@@ -210,19 +32,22 @@ func crossFile(crosstool *armCrosstool, cpu string) (string, error) {
 	return cf.Name(), nil
 }
 
-func releaseARM(ctx *cli.Context, out string, triple triple, cpu string) error {
+func releaseCross(ctx *cli.Context, out string, cpu crosstool.CPU) error {
 	src, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	crosstool, err := newARMCrosstool(triple)
+	crosstool, err := crosstool.For(cpu, crosstool.Options{
+		CC:  ctx.String("cross_cc"),
+		CXX: ctx.String("cross_cxx"),
+	})
 	if err != nil {
 		return err
 	}
 	defer crosstool.Cleanup()
 
-	crossF, err := crossFile(crosstool, cpu)
+	crossF, err := crossFile(crosstool)
 	if err != nil {
 		return err
 	}
@@ -329,14 +154,14 @@ func release(ctx *cli.Context) error {
 	case "aarch64":
 		// Processors used on 3B+ support this arch, but RPi OS does not.
 		// These are probably OK defaults for aarch64 though.
-		return releaseARM(ctx, out, aarch64Triple, "cortex-a53")
+		return releaseCross(ctx, out, crosstool.CortexA53)
 	case "armv7h":
 		// Used on Raspberry Pi 2B+. Should also work for newer
 		// chips running 32-bit RPi OS.
-		return releaseARM(ctx, out, armTriple, "cortex-a7")
+		return releaseCross(ctx, out, crosstool.CortexA7)
 	case "armv6h":
 		// Used on Raspberry Pi 0/1.
-		return releaseARM(ctx, out, armTriple, "arm1176jzf-s")
+		return releaseCross(ctx, out, crosstool.ARM1176JZF_S)
 	}
 
 	return fmt.Errorf("architecture %q not supported", ctx.Args().First())
@@ -355,6 +180,24 @@ var Command = &cli.Command{
 				"build against that. If unset, the system version (whether",
 				"present or not) will be used. Currently only supported by",
 				"AArch64 release.",
+			}, " "),
+		},
+		&cli.StringFlag{
+			Name:  "cross_cc",
+			Value: "clang",
+			Usage: strings.Join([]string{
+				"Name of the C compiler driver to use during cross compilation.",
+				"Defaults to 'clang'. The driver must support the `--target`",
+				"option.",
+			}, " "),
+		},
+		&cli.StringFlag{
+			Name:  "cross_cxx",
+			Value: "clang++",
+			Usage: strings.Join([]string{
+				"Name of the C++ compiler driver to use during cross",
+				"compilation. Defaults to 'clang'. The driver must support the",
+				"`--target` option.",
 			}, " "),
 		},
 		&cli.StringFlag{

--- a/tools/meta/crosstool/crosstool.go
+++ b/tools/meta/crosstool/crosstool.go
@@ -1,0 +1,352 @@
+// Package crosstool contains routiles for constructing cross-compilation
+// environments for various (ARM) CPUs.
+package crosstool
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"path"
+	"strings"
+	"text/template"
+
+	"meta/fetch"
+	"meta/project"
+	"meta/workspace"
+)
+
+var (
+	raspbianRoot = fetch.RemoteArchive{
+		URL:    "http://downloads.raspberrypi.org/raspbian_lite/archive/2019-04-09-22:48/root.tar.xz",
+		SHA256: "64af252aed817429e760cd3aa10f8b54713e678828f65fca8a1a76afe495ac61",
+		Format: fetch.TarXz,
+		ExtraOptions: []string{
+			"--exclude=./dev/*",
+		},
+	}
+
+	ubuntuAArch64Root = fetch.RemoteArchive{
+		URL:    "https://storage.googleapis.com/ashuffle-data/ubuntu_16.04_aarch64_root.tar.xz",
+		SHA256: "441d94b8e8ab42bf31bf98a04c87dd1de3e84586090d200d4bb4974960385605",
+		Format: fetch.TarXz,
+		ExtraOptions: []string{
+			"--strip-components=1",
+		},
+	}
+
+	llvmSource = fetch.RemoteArchive{
+		URL:    "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-project-11.0.0.tar.xz",
+		SHA256: "b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b",
+		Format: fetch.TarXz,
+		ExtraOptions: []string{
+			"--strip-components=1",
+		},
+	}
+)
+
+// Triple represents a target triple for a particular platform.
+type Triple struct {
+	Architecture string
+	Vendor       string
+	System       string
+	ABI          string
+}
+
+// String implements fmt.Stringer for Triple.
+func (t Triple) String() string {
+	return strings.Join([]string{
+		t.Architecture,
+		t.Vendor,
+		t.System,
+		t.ABI,
+	}, "-")
+}
+
+// CPU represents a CPU for which we can build a crosstool.
+type CPU string
+
+const (
+	CortexA53    CPU = "cortex-a53"
+	CortexA7     CPU = "cortex-a7"
+	ARM1176JZF_S CPU = "arm1176jzf-s"
+)
+
+// Triple returns the triple for the CPU.
+func (c CPU) Triple() Triple {
+	switch c {
+	case CortexA53:
+		return Triple{
+			Architecture: "aarch64",
+			Vendor:       "none",
+			System:       "linux",
+			ABI:          "gnu",
+		}
+	case CortexA7, ARM1176JZF_S:
+		return Triple{
+			Architecture: "arm",
+			Vendor:       "none",
+			System:       "linux",
+			ABI:          "gnueabihf",
+		}
+	}
+	panic("unreachable")
+}
+
+// String implements fmt.Stringer for this CPU.
+func (c CPU) String() string {
+	return string(c)
+}
+
+// Options which control how the crosstool is built.
+type Options struct {
+	// CC and CXX are the host-targeted compiler binaries used by the
+	// crosstool. If unset, then "clang", and "clang++" are used.
+	CC, CXX string
+}
+
+var crossfileTmpl = template.Must(
+	template.New("arm-crossfile").
+		Funcs(map[string]interface{}{
+			"joinSpace": func(strs []string) string {
+				return strings.Join(strs, " ")
+			},
+		}).
+		Parse(strings.Join([]string{
+			"[binaries]",
+			"c = '{{ .CC }}'",
+			"cpp = '{{ .CXX }}'",
+			"c_ld = 'lld'",
+			"cpp_ld = 'lld'",
+			// We have to set pkgconfig and cmake explicitly here, otherwise
+			// meson will not be able to find them. We just re-use the
+			// system versions, since we don't need any special arch-specific
+			// handing.
+			"pkgconfig = '{{ .PkgConfig }}'",
+			"cmake = '{{ .CMake }}'",
+			"",
+			"[properties]",
+			"sys_root = '{{ .Root }}'",
+			"c_args = '-mcpu={{ .CPU }} {{ .CFlags | joinSpace }}'",
+			"c_link_args = '{{ .LDFlags | joinSpace }}'",
+			"cpp_args = '-mcpu={{ .CPU }} {{ .CXXFlags | joinSpace }}'",
+			"cpp_link_args = '{{ .CXXLDFlags | joinSpace }}'",
+			"",
+			"[host_machine]",
+			"system = '{{ .CPU.Triple.System }}'",
+			"cpu_family = '{{ .CPU.Triple.Architecture }}'",
+			"cpu = '{{ .CPU }}'",
+			"endian = 'little'",
+		}, "\n")),
+)
+
+// Crosstool represents a cross-compiler environment. These can be created via
+// the `For` function for a specific CPU.
+type Crosstool struct {
+	*workspace.Workspace
+	libCXX *workspace.Workspace
+
+	CPU        CPU
+	PkgConfig  string
+	CMake      string
+	CC         string
+	CXX        string
+	CFlags     []string
+	CXXFlags   []string
+	LDFlags    []string
+	CXXLDFlags []string
+}
+
+// WriteCrossFile writes a Meson cross file for this crosstool to the given
+// io.Writer.
+func (c *Crosstool) WriteCrossFile(w io.Writer) error {
+	return crossfileTmpl.Execute(w, c)
+}
+
+// Cleanup cleans up this crosstool, removing any downloaded or built artifacts.
+func (c *Crosstool) Cleanup() error {
+	lErr := c.libCXX.Cleanup()
+	if err := c.Workspace.Cleanup(); err != nil {
+		if lErr != nil {
+			return fmt.Errorf("multiple cleanup errors: %v, %v", lErr, err)
+		}
+		return err
+	}
+	return lErr
+}
+
+func installLibCXX(cpu CPU, sysroot string, opts Options, into *workspace.Workspace) error {
+	flags := []string{
+		"--target=" + cpu.Triple().String(),
+		"-mcpu=" + cpu.String(),
+		"-fuse-ld=lld",
+		"--sysroot=" + sysroot,
+	}
+
+	if cpu == CortexA7 || cpu == ARM1176JZF_S {
+		flags = append(flags, "-marm")
+	}
+
+	base := project.CMakeOptions{
+		CCompiler:   opts.CC,
+		CXXCompiler: opts.CXX,
+		CFlags:      flags,
+		CXXFlags:    flags,
+		Extra: project.CMakeVariables{
+			"CMAKE_CROSSCOMPILING":  "YES",
+			"LLVM_TARGETS_TO_BUILD": "ARM",
+		},
+	}
+
+	src, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		return err
+	}
+	defer src.Cleanup()
+
+	if err := llvmSource.FetchTo(src.Root); err != nil {
+		return err
+	}
+
+	abiBuild, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		return err
+	}
+	defer abiBuild.Cleanup()
+
+	abi := base
+	abi.BuildDirectory = abiBuild.Root
+	abi.Extra["LIBCXXABI_ENABLE_SHARED"] = "NO"
+
+	abiProject, err := project.NewCMake(path.Join(src.Root, "libcxxabi"), abi)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Install(abiProject, into.Root); err != nil {
+		return err
+	}
+
+	libBuild, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		return err
+	}
+	defer libBuild.Cleanup()
+
+	lib := base
+	lib.BuildDirectory = libBuild.Root
+	lib.Extra["LIBCXX_CXX_ABI"] = "libcxxabi"
+	lib.Extra["LIBCXX_ENABLE_SHARED"] = "NO"
+	lib.Extra["LIBCXX_STANDALONE_BUILD"] = "YES"
+	lib.Extra["LIBCXX_CXX_ABI_INCLUDE_PATHS"] = path.Join(src.Root, "libcxxabi/include")
+
+	libProject, err := project.NewCMake(path.Join(src.Root, "libcxx"), lib)
+	if err != nil {
+		return err
+	}
+
+	return project.Install(libProject, into.Root)
+}
+
+func fetchSysroot(cpu CPU) (*workspace.Workspace, error) {
+	sys, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		return nil, err
+	}
+
+	var root fetch.RemoteArchive
+	switch cpu {
+	case CortexA53:
+		root = ubuntuAArch64Root
+	case CortexA7, ARM1176JZF_S:
+		root = raspbianRoot
+	}
+
+	if err := root.FetchTo(sys.Root); err != nil {
+		sys.Cleanup()
+		return nil, err
+	}
+	return sys, nil
+}
+
+// For creates a new crosstool for the given CPU, using the given options.
+func For(cpu CPU, opts Options) (*Crosstool, error) {
+	if opts.CC == "" {
+		opts.CC = "clang"
+	}
+	if opts.CXX == "" {
+		opts.CXX = "clang++"
+	}
+	wantBins := []string{
+		"pkg-config",
+		"cmake",
+		opts.CC,
+		opts.CXX,
+	}
+
+	binPaths := make(map[string]string)
+	for _, bin := range wantBins {
+		path, err := exec.LookPath(bin)
+		if err != nil {
+			return nil, err
+		}
+		binPaths[bin] = path
+	}
+
+	sys, err := fetchSysroot(cpu)
+	if err != nil {
+		return nil, err
+	}
+
+	libcxx, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		sys.Cleanup()
+		return nil, err
+	}
+
+	if err := installLibCXX(cpu, sys.Root, opts, libcxx); err != nil {
+		sys.Cleanup()
+		libcxx.Cleanup()
+		return nil, err
+	}
+
+	commonFlags := []string{
+		"--sysroot=" + sys.Root,
+		"--target=" + cpu.Triple().String(),
+	}
+
+	ct := &Crosstool{
+		Workspace: sys,
+		libCXX:    libcxx,
+		CPU:       cpu,
+		PkgConfig: binPaths["pkg-config"],
+		CMake:     binPaths["cmake"],
+		CC:        binPaths[opts.CC],
+		CXX:       binPaths[opts.CXX],
+		CFlags:    commonFlags,
+		CXXFlags: append(commonFlags,
+			"-nostdinc++",
+			"-I"+path.Join(libcxx.Root, "include/c++/v1"),
+		),
+		LDFlags: append(commonFlags,
+			"-fuse-ld=lld",
+			"-lpthread",
+		),
+		CXXLDFlags: append(commonFlags,
+			"-fuse-ld=lld",
+			"-nostdlib++",
+			"-L"+path.Join(libcxx.Root, "lib"),
+			// Use the -l:lib...a form to avoid accidentally linking the
+			// libraries dynamically.
+			"-l:libc++.a",
+			"-l:libc++abi.a",
+			"-lpthread",
+		),
+	}
+
+	if cpu == CortexA7 || cpu == ARM1176JZF_S {
+		ct.CFlags = append(ct.CFlags, "-marm")
+		ct.CXXFlags = append(ct.CXXFlags, "-marm")
+	}
+
+	return ct, nil
+}


### PR DESCRIPTION
Meta is currently using the official ARM-released crosstool to do ARM32
ashuffle release builds. This has a couple issues. Namely, the ARM
crosstool only supports armv7 or later, but the RPi Zero is only armv6.
It may also be (or later get-out of) sync with the envrionments users
are using (primarily RPi OS presumably).

This change switches to a Clang/LLVM-based cross build using OS
distribution images themselves as sysroots. This guarantees we will
maintain compatibility with the platforms most of our users are using.
One slight snag of this approach, is that the target distribution images
typically bundle versions of the C++ stdlib that are too old for
ashuffle to use (since we use C++17). To get around this, we actually
build LLVM's libc++ (using the same OS image), and then statically link
it into ashuffle itself.

As of this change, the cross build sysroots are based on:

* armv6h/armv7h: Raspbian 2019-04-02, a fairly old Raspbian.
* arm64: Ubuntu xenial, the oldest supported LTS release.

Fixes Issue #80 