### PR TITLE
Upgrade to integration-root with newer meson

### DIFF
--- a/t/docker/Dockerfile.ubuntu
+++ b/t/docker/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM jkz0/ashuffle-integration-root:latest
+FROM ghcr.io/joshkunz/ashuffle-integration-root:v2.1.1
 
 COPY /tools/meta/ /opt/meta
 RUN cd /opt/meta && go build


### PR DESCRIPTION
MPD appears to have upgraded their minimum meson version, so we need to bump
the version of meson in the root container so we can build <latest>.