### PR TITLE
Fix exclude argument parsing

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -172,7 +172,7 @@ Parser::Status Parser::Consume(std::string_view arg) {
     prev_ = arg;
     Parser::State next = std::get<Parser::State>(next_or_err);
     // If we're transitioning out of a rule...
-    if (state_ == kRule && next != kRule) {
+    if (state_ == kRule && (next != kRule && next != kRuleValue)) {
         FlushRule();
     }
     state_ = next;

--- a/src/rule.h
+++ b/src/rule.h
@@ -40,6 +40,9 @@ class Rule {
     // Empty returns true when this rule matches no patterns.
     inline bool Empty() const { return patterns_.empty(); }
 
+    // Size returns the number of patterns in this rule.
+    inline size_t Size() const { return patterns_.size(); }
+
     // Add the given pattern to this rule.
     void AddPattern(enum mpd_tag_type, std::string value);
 


### PR DESCRIPTION
Should fix #112. The current exclude rule parser reads each tag as a separate rule, instead of an additional pattern.