### PR TITLE
Fix release binary build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,12 +31,10 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        sanitizer: ["none", "asan", "msan"]
+        sanitizer: ["none", "asan"]
         include:
           - sanitizer: asan
             name_suffix: " (ASAN)"
-          - sanitizer: msan
-            name_suffix: " (MSAN)"
     name: Unit Test${{ matrix.name_suffix }}
     runs-on: ubuntu-latest
     needs: [check-format, check-lint]

--- a/scripts/github/common.sh
+++ b/scripts/github/common.sh
@@ -1,6 +1,6 @@
-MESON_VERSION="0.54.0"
-GO_VERSION="1.16.2"
-LLVM_RELEASE="10"
+MESON_VERSION="0.60.2"
+GO_VERSION="1.17.6"
+LLVM_RELEASE="12"
 GIMMIE_URL="https://raw.githubusercontent.com/travis-ci/gimme/master/gimme"
 
 CLANG_CC="clang-${LLVM_RELEASE}"

--- a/scripts/github/release
+++ b/scripts/github/release
@@ -1,13 +1,39 @@
-#!/bin/sh
+#!/bin/bash
 
 . "scripts/github/common.sh"
 
 setup
+
+assure_format() {
+    local f="$1"
+    local match="$2"
+
+    if ! [[ -e "$f" ]]; then
+        die "cannot check format of '$f' file does not exist"
+    fi
+
+    local arch="$(readelf -h "$f" | sed -En 's/\s+Machine:\s+(\S.*)$/\1/p')"
+    if [[ $? -ne 0 ]]; then
+        die "failed to fetch ELF machine of file '$f'"
+    fi
+
+    [[ "$arch" =~ "$match" ]]
+    local status=$?
+    if [[ $status -eq 1 ]]; then
+        die "mismatched machine for $f. Got '$arch' wanted $match'" >&2
+    fi
+    return 0
+}
+
 mkdir -p release
 tools/meta/meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
+assure_format release/ashuffle.x86_64-linux-gnu X86-64
 tools/meta/meta release -o release/ashuffle.aarch64-linux-gnu \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" aarch64 || die "couldn't build aarch64"
+assure_format release/ashuffle.aarch64-linux-gnu AArch64
 tools/meta/meta release -o release/ashuffle.armv7h-linux-gnueabihf \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv7h || die "couldn't build armv7h"
+assure_format release/ashuffle.armv7h-linux-gnueabihf ARM
 tools/meta/meta release -o release/ashuffle.armv6h-linux-gnueabihf \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv6h || die "couldn't build armv6h"
+assure_format release/ashuffle.armv6h-linux-gnueabihf ARM

--- a/scripts/github/unit-test
+++ b/scripts/github/unit-test
@@ -12,9 +12,6 @@ if test "$#" -gt 0; then
         asan)
             SANITIZER=asan
             ;;
-        msan)
-            SANITIZER=msan
-            ;;
         *)
             die "unrecognized mode $1"
     esac
@@ -31,11 +28,6 @@ case "${SANITIZER}" in
     asan)
         env CC="${CLANG_CC}" CXX="${CLANG_CXX}" LDFLAGS="-fsanitize=address" \
             meson -Dtests=enabled -Db_sanitize=address -Db_lundef=false "${BUILD_ROOT}" \
-            || die "couldn't run meson with sanitizer ${SANITIZER}"
-        ;;
-    msan)
-        env CC="${CLANG_CC}" CXX="${CLANG_CXX}" LDFLAGS="-fsanitize=memory" \
-            meson -Dtests=enabled -Db_sanitize=memory -Db_lundef=false "${BUILD_ROOT}" \
             || die "couldn't run meson with sanitizer ${SANITIZER}"
         ;;
     *)


### PR DESCRIPTION
Looks like my local meson version was much newer than the one we are using in CI, so the `meta` build was misconfigured. This PR:

* Upgrades the meson & compiler version
* Disables msan (broken by the updated compiler)
* Adds extra `readelf` checks to make sure that release binaries are the correct architecture