### PR TITLE
meson.build: add unsupported_use_system_yamlcpp option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -101,9 +101,13 @@ else
   endforeach
 endif
 
-yaml_cpp = cmake.subproject('yaml-cpp', cmake_options: cmake_common_args + [
-  '-DYAML_BUILD_SHARED_LIBS=OFF',
-])
+if not get_option('unsupported_use_system_yamlcpp')
+  yaml_cpp = cmake.subproject('yaml-cpp', cmake_options: cmake_common_args + [
+    '-DYAML_BUILD_SHARED_LIBS=OFF',
+  ]).dependency('yaml-cpp')
+else
+  yaml_cpp = dependency('yaml-cpp')
+endif
 
 libmpdclient = dependency('libmpdclient')
 
@@ -138,9 +142,7 @@ libashuffle = static_library(
   'ashuffle',
   sources,
   include_directories: src_inc,
-  dependencies: absl_deps + [
-    yaml_cpp.dependency('yaml-cpp'),
-  ],
+  dependencies: absl_deps + [yaml_cpp],
 )
 
 ashuffle = executable(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('tests', type : 'feature', value : 'disabled')
 option('unsupported_use_system_absl', type : 'boolean', value : 'false')
 option('unsupported_use_system_gtest', type : 'boolean', value : 'false')
+option('unsupported_use_system_yamlcpp', type : 'boolean', value : 'false')


### PR DESCRIPTION
distros don't like building with embedded version of a lib, allow building with the system version of libyaml-cpp

--- 
note I personally would go further and check for system dep as optional and only use the wrap if system isn't present, as there isn't as much adherence with the version of yamlcpp as we have for absl, but I've just kept it the same as the other unsupported_use_system_xx for consistency