### PR TITLE
Automatically reconnect to MPD after disconnection

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ absl_libs = [
   'absl_crc_internal',
   'absl_crc_cord_state',
   'absl_crc32c',
+  'absl_crc_cpu_detect',
   'absl_cord_internal',
   'absl_cordz_functions',
   'absl_cordz_handle',

--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,7 @@ sources = files(
   'src/load.cc',
   'src/args.cc',
   'src/getpass.cc',
+  'src/log.cc',
   'src/rule.cc',
   'src/shuffle.cc',
 )
@@ -197,6 +198,7 @@ if get_option('tests').enabled()
     'load': ['t/load_test.cc'],
     'args': ['t/args_test.cc'],
     'ashuffle': ['t/ashuffle_test.cc'],
+    'log': ['t/log_test.cc'],
     'mpd_fake': ['t/mpd_fake_test.cc'],
   }
 

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,26 @@ absl_libs = [
   'absl_time',
   'absl_base',
   'absl_spinlock_wait',
+
+  # Via Status & Time:
+  'absl_cord',
+  'absl_cord_internal',
+  'absl_cordz_functions',
+  'absl_cordz_handle',
+  'absl_cordz_info',
+  'absl_cordz_update_tracker',
+  'absl_debugging_internal',
+  'absl_exponential_biased',
+  'absl_graphcycles_internal',
+  'absl_malloc_internal',
+  'absl_stacktrace',
+  'absl_status',
+  'absl_statusor',
+  'absl_symbolize',
+  'absl_synchronization',
+  'absl_throw_delegate',
+  'absl_time_zone',
+  'absl_demangle_internal',
 ]
 
 absl_deps = []
@@ -131,10 +151,10 @@ libversion = static_library(
 )
 
 sources = files(
-  'src/ashuffle.cc',
-  'src/load.cc',
   'src/args.cc',
+  'src/ashuffle.cc',
   'src/getpass.cc',
+  'src/load.cc',
   'src/log.cc',
   'src/rule.cc',
   'src/shuffle.cc',
@@ -193,13 +213,13 @@ if get_option('tests').enabled()
   ]
 
   tests = {
-    'rule': ['t/rule_test.cc'],
-    'shuffle': ['t/shuffle_test.cc'],
-    'load': ['t/load_test.cc'],
     'args': ['t/args_test.cc'],
     'ashuffle': ['t/ashuffle_test.cc'],
+    'load': ['t/load_test.cc'],
     'log': ['t/log_test.cc'],
     'mpd_fake': ['t/mpd_fake_test.cc'],
+    'rule': ['t/rule_test.cc'],
+    'shuffle': ['t/shuffle_test.cc'],
   }
 
   foreach test_name, test_sources : tests

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,10 @@ absl_libs = [
 
   # Via Status & Time:
   'absl_cord',
+  'absl_strerror',
+  'absl_crc_internal',
+  'absl_crc_cord_state',
+  'absl_crc32c',
   'absl_cord_internal',
   'absl_cordz_functions',
   'absl_cordz_handle',
@@ -82,6 +86,7 @@ absl_libs = [
   'absl_statusor',
   'absl_symbolize',
   'absl_synchronization',
+  'absl_kernel_timeout_internal',
   'absl_throw_delegate',
   'absl_time_zone',
   'absl_demangle_internal',

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ usage: ashuffle [-h] [-n] [-v] [[-e PATTERN ...] ...] [-o NUMBER]
 
 Optional Arguments:
    -h,-?,--help      Display this help message.
+   --by-album        Same as '--group-by album date'.
    -e,--exclude      Specify things to remove from shuffle (think
                      blacklist). A PATTERN should follow the exclude
                      flag.
@@ -186,13 +187,13 @@ Optional Arguments:
                      filename to retrive URI's from standard in. This
                      can be used to pipe song URI's from another program
                      into ashuffle.
-   --by-album        Same as '--group-by album date'.
    -g,--group-by     Shuffle songs grouped by the given tags. For
                      example 'album' could be used as the tag, and an
                      entire album's worth of songs would be queued
                      instead of one song at a time.
    --host            Specify a hostname or IP address to connect to.
                      Defaults to `localhost`.
+   --log-file        Path to write log output to. Defaults to stderr.
    -n,--no-check     When reading URIs from a file, don't check to
                      ensure that the URIs match the given exclude rules.
                      This option is most helpful when shuffling songs

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ tweaks, and their meanings:
 | ---- | ------ | ------- | ----------- |
 | `exit-on-db-update` | Boolean | `no` | If set to a true value, then ashuffle will exit when the MPD database is updated. This can be useful when used in conjunction with the `-f -` option, as it allows you to re-start ashuffle with a new music list. |
 | `play-on-startup` | Boolean | `yes` | If set to a true value, ashuffle starts playing music if MPD is paused, stopped, or the queue is empty on startup. If set to false, then ashuffle will not enqueue any music until a song is enqueued for the first time. |
+| `reconnect-timeout` | Duration `> 0` | `10s` | Configures the amount of time ashuffle will spend attempting to reconnect to MPD after a temporary disconnection. After this amount of time, ashuffle will give up attempting to reconnect and quit. |
 | `suspend-timeout` | Duration `> 0` | `0ms` | Enables "suspend" mode, which may be useful to users that use ashuffe in a workflow where they clear their queue. In this mode, if the queue is cleared while ashuffle is running, ashuffle will wait for `suspend-timeout`. If songs were added to the queue during that period of time (i.e., the queue is no longer empty), then ashuffle suspends itself, and will not add any songs to the queue (even if the queue runs out) until the queue is cleared again, at which point normal operations resume. This was add to support use-cases like the one given in issue #13, where a music player had a "play album" mode that would clear the queue, and then play an album. See below for the duration format. |
 | `window-size` | Integer `>=1` | `7` | Sets the size of the "window" used for the shuffle algorithm. See the section on the [shuffle algorithm](#shuffle-algorithm) for more details. In-short: Lower numbers mean more frequent repeats, and higher numbers mean less frequent repeats. |
 
@@ -358,14 +359,14 @@ requests are welcome.
 
 ## installing from source
 
-For platforms without a binary release, you'll have to build from source. 
+For platforms without a binary release, you'll have to build from source.
 ashuffle is designed to have a small number of dependencies, and we try to
 keep the build relatively straightforward. That said, you will need a
 relatively recent C++ compiler. Clang 7+, or GCC 8+ should work.
 
 If you have any trouble building ashuffle, please file an issue on Github,
 or email the ashuffle users group. Make sure to your compiler version, meson
-version, the commands you tried to execute, and any errors that were produced. 
+version, the commands you tried to execute, and any errors that were produced.
 
 ### dependencies
 
@@ -391,7 +392,7 @@ debian-based distributions (including ubuntu) it can be installed like so:
 
 ashuffle relies on git submodules to track libraries it depends on. These
 libraries are not distributed in the source tarballs provided by Github,
-so you need to use git to get ashuffle when building from source. 
+so you need to use git to get ashuffle when building from source.
 
 Start by cloning ashuffle:
 

--- a/src/args.cc
+++ b/src/args.cc
@@ -272,6 +272,21 @@ std::variant<Parser::State, ParseError> Parser::ParseTweak(
         return kNone;
     }
 
+    if (key == "reconnect-timeout") {
+        if (!absl::ParseDuration(value, &opts_.tweak.reconnect_timeout)) {
+            return ParseError(absl::StrFormat(
+                "reconnect-timeout must be a duration with units "
+                "e.g., 30s ('%s' given)",
+                value));
+        }
+        if (opts_.tweak.reconnect_timeout < absl::ZeroDuration()) {
+            return ParseError(absl::StrFormat(
+                "reconnect-timeout must be a positive duration ('%s' given)",
+                value));
+        }
+        return kNone;
+    }
+
     if (key == "exit-on-db-update") {
         auto v = ParseBool(value);
         if (!v.has_value()) {

--- a/src/args.h
+++ b/src/args.h
@@ -57,6 +57,10 @@ class Options {
         // intented to be used in cases where the user is passing in a
         // list of songs via -f, and they may want to re-generate that list.
         bool exit_on_db_update = false;
+        // Duration to attempt to reconnect to MPD after a disconnection.
+        // After this time, ashuffle will assume it cannot reconnect and
+        // will quit.
+        absl::Duration reconnect_timeout = absl::Seconds(10);
     } tweak = {};
     std::vector<enum mpd_tag_type> group_by = {};
 

--- a/src/args.h
+++ b/src/args.h
@@ -35,6 +35,7 @@ class Options {
     std::vector<Rule> ruleset;
     unsigned queue_only = 0;
     std::istream *file_in = nullptr;
+    std::ostream *log_file = nullptr;
     bool check_uris = true;
     unsigned queue_buffer = 0;
     std::optional<std::string> host = {};
@@ -89,12 +90,21 @@ class Options {
         owned_file_ = std::move(is);
     };
 
+    // Same as InternalTakeIstream but for the log file ostream.
+    void InternalTakeLog(std::unique_ptr<std::ostream> &&os) {
+        log_file = os.get();
+        owned_log_file_ = std::move(os);
+    }
+
    private:
     // The owned_file is set if this Options class owns the file_in ptr.
     // The file_in ptr is only *sometimes* owned. For example, the file_in ptr
     // may point to std::cin, which has static lifetime, and is not owned by
     // this object.
     std::unique_ptr<std::istream> owned_file_;
+
+    // Same as above.
+    std::unique_ptr<std::ostream> owned_log_file_;
 };
 
 // Print the help message on the given output stream, and return the input

--- a/src/ashuffle.h
+++ b/src/ashuffle.h
@@ -12,19 +12,27 @@
 #include <mpd/client.h>
 
 #include "args.h"
+#include "load.h"
 #include "mpd.h"
 #include "rule.h"
 #include "shuffle.h"
 
 namespace ashuffle {
 
+namespace {
+
+// A getpass_f value that can be used in non-interactive mode.
+std::function<std::string()>* kNonInteractiveGetpass = nullptr;
+
+}  // namespace
+
 // `MPD_PORT` environment variables. If a password is needed, no password can
 // be found in MPD_HOST, then `getpass_f' will be used to prompt the user
-// for a password. If `getpass_f' is NULL, the a default password prompt
-// (based on getpass) will be used.
+// for a password. If `getpass_f' is NULL, then a password will not be
+// prompted.
 absl::StatusOr<std::unique_ptr<mpd::MPD>> Connect(
     const mpd::Dialer& d, const Options& options,
-    std::function<std::string()>& getpass_f);
+    std::function<std::string()>* getpass_f);
 
 struct TestDelegate {
     bool (*until_f)() = nullptr;
@@ -38,7 +46,13 @@ struct TestDelegate {
 absl::Status Loop(mpd::MPD* mpd, ShuffleChain* songs, const Options& options,
                   TestDelegate d = TestDelegate());
 
-// Print the size of the database to the given stream, accounting for grouping.
+// Return a loader capable of re-loading the current shuffle chain given
+// a particular set of options. If it's not possible to create such a
+// loader, returns an empty option.
+std::optional<std::unique_ptr<Loader>> Reloader(mpd::MPD* mpd,
+                                                const Options& options);
+// Print the size of the database to the given stream, accounting for
+// grouping.
 void PrintChainLength(std::ostream& stream, const ShuffleChain& chain);
 
 }  // namespace ashuffle

--- a/src/ashuffle.h
+++ b/src/ashuffle.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include <absl/status/statusor.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
 #include <mpd/client.h>
@@ -21,8 +22,9 @@ namespace ashuffle {
 // be found in MPD_HOST, then `getpass_f' will be used to prompt the user
 // for a password. If `getpass_f' is NULL, the a default password prompt
 // (based on getpass) will be used.
-std::unique_ptr<mpd::MPD> Connect(const mpd::Dialer& d, const Options& options,
-                                  std::function<std::string()>& getpass_f);
+absl::StatusOr<std::unique_ptr<mpd::MPD>> Connect(
+    const mpd::Dialer& d, const Options& options,
+    std::function<std::string()>& getpass_f);
 
 struct TestDelegate {
     bool (*until_f)() = nullptr;
@@ -33,8 +35,8 @@ struct TestDelegate {
 // queue finishes playing. This is the core loop of `ashuffle`. The tests
 // delegate is used during tests to observe loop effects. It should be set to
 // NULL during normal operations.
-void Loop(mpd::MPD* mpd, ShuffleChain* songs, const Options& options,
-          TestDelegate d = TestDelegate());
+absl::Status Loop(mpd::MPD* mpd, ShuffleChain* songs, const Options& options,
+                  TestDelegate d = TestDelegate());
 
 // Print the size of the database to the given stream, accounting for grouping.
 void PrintChainLength(std::ostream& stream, const ShuffleChain& chain);

--- a/src/getpass.cc
+++ b/src/getpass.cc
@@ -20,6 +20,11 @@ void SetEcho(FILE *stream, bool echo_state, bool echo_nl_state) {
     struct termios flags;
     int res = tcgetattr(fileno(stream), &flags);
     if (res != 0) {
+        if (errno == ENOTTY) {
+            // If the output device is not a tty, then we don't need to
+            // worry about the echo.
+            return;
+        }
         perror("SetEcho (tcgetattr)");
         std::exit(1);
     }

--- a/src/load.cc
+++ b/src/load.cc
@@ -34,7 +34,12 @@ void MPDLoader::Load(ShuffleChain *songs) {
         metadata = mpd::MPD::MetadataOption::kOmit;
     }
 
-    std::unique_ptr<mpd::SongReader> reader = mpd_->ListAll(metadata);
+    auto reader_or = mpd_->ListAll(metadata);
+    if (!reader_or.ok()) {
+        Die("Failed to get reader: %s", reader_or.status().ToString());
+    }
+    std::unique_ptr<mpd::SongReader> reader = std::move(*reader_or);
+
     while (!reader->Done()) {
         std::unique_ptr<mpd::Song> song = *reader->Next();
         if (!Verify(*song)) {

--- a/src/log.cc
+++ b/src/log.cc
@@ -1,0 +1,25 @@
+#include <log.h>
+
+#include <iostream>
+
+namespace ashuffle {
+namespace log {
+
+std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
+    out << loc.file << ":" << loc.line << " in " << loc.function;
+    return out;
+}
+
+void SetOutput(std::ostream& output) {
+    DefaultLogger().SetOutput(output);
+}
+
+Logger& DefaultLogger() {
+    // static-lifetime logger.
+    static Logger logger;
+    return logger;
+}
+
+} // namespace log
+} // namespace ashuffle
+

--- a/src/log.cc
+++ b/src/log.cc
@@ -10,9 +10,7 @@ std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {
     return out;
 }
 
-void SetOutput(std::ostream& output) {
-    DefaultLogger().SetOutput(output);
-}
+void SetOutput(std::ostream& output) { DefaultLogger().SetOutput(output); }
 
 Logger& DefaultLogger() {
     // static-lifetime logger.
@@ -20,6 +18,5 @@ Logger& DefaultLogger() {
     return logger;
 }
 
-} // namespace log
-} // namespace ashuffle
-
+}  // namespace log
+}  // namespace ashuffle

--- a/src/log.cc
+++ b/src/log.cc
@@ -3,6 +3,19 @@
 #include <iostream>
 
 namespace ashuffle {
+
+std::ostream& operator<<(std::ostream& os, const Log::Level& level) {
+    switch (level) {
+        case Log::Level::kInfo:
+            os << "INFO";
+            break;
+        case Log::Level::kError:
+            os << "ERROR";
+            break;
+    }
+    return os;
+}
+
 namespace log {
 
 std::ostream& operator<<(std::ostream& out, const SourceLocation& loc) {

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,60 @@
+#ifndef __ASHUFFLE_LOG_H__
+#define __ASHUFFLE_LOG_H__
+
+#include <string_view>
+
+#include <absl/strings/str_format.h>
+
+#include "log_internal.h"
+
+namespace ashuffle {
+
+class Log final {
+    public:
+        Log(log::SourceLocation loc = log::SourceLocation())
+            : loc_(loc){}
+
+        template <typename... Args>
+        void Info(const absl::FormatSpec<Args...>& fmt, Args... args) {
+            WriteLog(Level::kInfo, fmt, args...);
+        }
+
+        template <typename... Args>
+        void Error(const absl::FormatSpec<Args...>& fmt, Args... args) {
+            WriteLog(Level::kError, fmt, args...);
+        }
+
+    private:
+        enum class Level {
+            kInfo,
+            kError,
+        };
+
+        template <typename... Args>
+        void WriteLog(Level level, const absl::FormatSpec<Args...>& fmt, Args... args) {
+            const char* level_str = nullptr;
+            switch (level) {
+            case Level::kInfo:
+                level_str = "INFO";
+                break;
+            case Level::kError:
+                level_str = "ERROR";
+                break;
+            }
+            log::DefaultLogger().Stream() << level_str << " " << loc_ << ": " << absl::StrFormat(fmt, args...) << std::endl;
+        }
+
+        log::SourceLocation loc_;
+};
+
+namespace log {
+
+// Set the output of the default logger to the given ostream. The ostream must
+// have program lifetime.
+void SetOutput(std::ostream& output);
+
+} // namespace log
+} // namespace ashuffle
+
+#endif // __ASHUFFLE_LOG_H__
+

--- a/src/log.h
+++ b/src/log.h
@@ -18,9 +18,17 @@ class Log final {
         WriteLog(Level::kInfo, fmt, args...);
     }
 
+    void InfoStr(std::string_view message) {
+        WriteLogStr(Level::kInfo, message);
+    }
+
     template <typename... Args>
     void Error(const absl::FormatSpec<Args...>& fmt, Args... args) {
         WriteLog(Level::kError, fmt, args...);
+    }
+
+    void ErrorStr(std::string_view message) {
+        WriteLogStr(Level::kError, message);
     }
 
    private:
@@ -29,20 +37,18 @@ class Log final {
         kError,
     };
 
+    friend std::ostream& operator<<(std::ostream&, const Level&);
+
+    void WriteLogStr(Level level, std::string_view message) {
+        log::DefaultLogger().Stream()
+            << level << " " << loc_ << ": " << message << std::endl;
+    }
+
     template <typename... Args>
     void WriteLog(Level level, const absl::FormatSpec<Args...>& fmt,
                   Args... args) {
-        const char* level_str = nullptr;
-        switch (level) {
-            case Level::kInfo:
-                level_str = "INFO";
-                break;
-            case Level::kError:
-                level_str = "ERROR";
-                break;
-        }
         log::DefaultLogger().Stream()
-            << level_str << " " << loc_ << ": " << absl::StrFormat(fmt, args...)
+            << level << " " << loc_ << ": " << absl::StrFormat(fmt, args...)
             << std::endl;
     }
 

--- a/src/log.h
+++ b/src/log.h
@@ -10,41 +10,43 @@
 namespace ashuffle {
 
 class Log final {
-    public:
-        Log(log::SourceLocation loc = log::SourceLocation())
-            : loc_(loc){}
+   public:
+    Log(log::SourceLocation loc = log::SourceLocation()) : loc_(loc) {}
 
-        template <typename... Args>
-        void Info(const absl::FormatSpec<Args...>& fmt, Args... args) {
-            WriteLog(Level::kInfo, fmt, args...);
-        }
+    template <typename... Args>
+    void Info(const absl::FormatSpec<Args...>& fmt, Args... args) {
+        WriteLog(Level::kInfo, fmt, args...);
+    }
 
-        template <typename... Args>
-        void Error(const absl::FormatSpec<Args...>& fmt, Args... args) {
-            WriteLog(Level::kError, fmt, args...);
-        }
+    template <typename... Args>
+    void Error(const absl::FormatSpec<Args...>& fmt, Args... args) {
+        WriteLog(Level::kError, fmt, args...);
+    }
 
-    private:
-        enum class Level {
-            kInfo,
-            kError,
-        };
+   private:
+    enum class Level {
+        kInfo,
+        kError,
+    };
 
-        template <typename... Args>
-        void WriteLog(Level level, const absl::FormatSpec<Args...>& fmt, Args... args) {
-            const char* level_str = nullptr;
-            switch (level) {
+    template <typename... Args>
+    void WriteLog(Level level, const absl::FormatSpec<Args...>& fmt,
+                  Args... args) {
+        const char* level_str = nullptr;
+        switch (level) {
             case Level::kInfo:
                 level_str = "INFO";
                 break;
             case Level::kError:
                 level_str = "ERROR";
                 break;
-            }
-            log::DefaultLogger().Stream() << level_str << " " << loc_ << ": " << absl::StrFormat(fmt, args...) << std::endl;
         }
+        log::DefaultLogger().Stream()
+            << level_str << " " << loc_ << ": " << absl::StrFormat(fmt, args...)
+            << std::endl;
+    }
 
-        log::SourceLocation loc_;
+    log::SourceLocation loc_;
 };
 
 namespace log {
@@ -53,8 +55,7 @@ namespace log {
 // have program lifetime.
 void SetOutput(std::ostream& output);
 
-} // namespace log
-} // namespace ashuffle
+}  // namespace log
+}  // namespace ashuffle
 
-#endif // __ASHUFFLE_LOG_H__
-
+#endif  // __ASHUFFLE_LOG_H__

--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -2,8 +2,8 @@
 #define __ASHUFFLE_LOG_INTERNAL_H__
 
 #include <cassert>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include <absl/strings/str_format.h>
 
@@ -26,30 +26,27 @@ std::ostream& operator<<(std::ostream&, const SourceLocation&);
 // Logger is an object that owns the output file and standard formatting
 // for logs.
 class Logger final {
- public:
-     Logger(){};
+   public:
+    Logger(){};
 
-     void SetOutput(std::ostream& output) {
-         output_ = &output;
-     }
+    void SetOutput(std::ostream& output) { output_ = &output; }
 
-     std::ostream& Stream() {
+    std::ostream& Stream() {
         static std::ofstream devnull("/dev/null");
-         if (output_ != nullptr) {
-             return *output_;
-         }
-         return devnull;
-     }
+        if (output_ != nullptr) {
+            return *output_;
+        }
+        return devnull;
+    }
 
- private:
-     std::ostream* output_;
+   private:
+    std::ostream* output_;
 };
 
 // Fetch the default logger.
 Logger& DefaultLogger();
 
-} // namespace log
-} // namespace ashuffle
+}  // namespace log
+}  // namespace ashuffle
 
-
-#endif // __ASHUFFLE_LOG_INTERNAL_H__
+#endif  // __ASHUFFLE_LOG_INTERNAL_H__

--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -1,0 +1,55 @@
+#ifndef __ASHUFFLE_LOG_INTERNAL_H__
+#define __ASHUFFLE_LOG_INTERNAL_H__
+
+#include <cassert>
+#include <iostream>
+#include <fstream>
+
+#include <absl/strings/str_format.h>
+
+namespace ashuffle {
+namespace log {
+
+struct SourceLocation final {
+    SourceLocation(const std::string_view file = __builtin_FILE(),
+                   const std::string_view function = __builtin_FUNCTION(),
+                   unsigned line = __builtin_LINE())
+        : file(file), function(function), line(line) {}
+
+    const std::string_view file;
+    const std::string_view function;
+    const unsigned line;
+};
+
+std::ostream& operator<<(std::ostream&, const SourceLocation&);
+
+// Logger is an object that owns the output file and standard formatting
+// for logs.
+class Logger final {
+ public:
+     Logger(){};
+
+     void SetOutput(std::ostream& output) {
+         output_ = &output;
+     }
+
+     std::ostream& Stream() {
+        static std::ofstream devnull("/dev/null");
+         if (output_ != nullptr) {
+             return *output_;
+         }
+         return devnull;
+     }
+
+ private:
+     std::ostream* output_;
+};
+
+// Fetch the default logger.
+Logger& DefaultLogger();
+
+} // namespace log
+} // namespace ashuffle
+
+
+#endif // __ASHUFFLE_LOG_INTERNAL_H__

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,26 +1,39 @@
 #include <stdlib.h>
 #include <time.h>
 #include <cassert>
+#include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <string>
 #include <variant>
 #include <vector>
 
+#include <absl/time/clock.h>
 #include <mpd/connection.h>
 
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "absl/time/time.h"
 #include "args.h"
 #include "ashuffle.h"
 #include "getpass.h"
 #include "load.h"
+#include "log.h"
 #include "mpd_client.h"
 #include "shuffle.h"
 #include "version.h"
 
 using namespace ashuffle;
 
-namespace {
+// This is the maximum amount of time that ashuffle is allowed to be
+// disconnected from MPD before it exits. This catches cases where the
+// environment changes and it would be impossible for ashuffle to reconnect.
+const absl::Duration kMaxDisconnectedTime = absl::Seconds(10);
 
+// The amount of time to wait between reconnection attempts.
+const absl::Duration kReconnectWait = absl::Milliseconds(250);
+
+namespace {
 std::unique_ptr<Loader> BuildLoader(mpd::MPD* mpd, const Options& opts) {
     if (opts.file_in != nullptr && opts.check_uris) {
         return std::make_unique<FileMPDLoader>(mpd, opts.ruleset, opts.group_by,
@@ -30,6 +43,19 @@ std::unique_ptr<Loader> BuildLoader(mpd::MPD* mpd, const Options& opts) {
     }
 
     return std::make_unique<MPDLoader>(mpd, opts.ruleset, opts.group_by);
+}
+
+void LoopOnce(mpd::MPD* mpd, ShuffleChain& songs, const Options& options) {
+    absl::Time start = absl::Now();
+    absl::Status status = Loop(mpd, &songs, options);
+    absl::Duration loop_length = absl::Now() - start;
+    if (!status.ok()) {
+        Log().Error("LOOP failed after %s with error: %s",
+                    absl::FormatDuration(loop_length), status.ToString());
+    } else {
+        Log().Info("LOOP exited successfully after %s (probably a bug)",
+                   absl::FormatDuration(loop_length));
+    }
 }
 
 }  // namespace
@@ -67,12 +93,23 @@ int main(int argc, const char* argv[]) {
         exit(EXIT_FAILURE);
     }
 
-    std::function<std::string()> pass_f = [] {
-        return GetPass(stdin, stdout, "mpd password: ");
+    log::SetOutput(std::cerr);
+
+    bool disable_reconnect = false;
+    std::function<std::string()> pass_f = [&disable_reconnect] {
+        disable_reconnect = true;
+        std::string pass = GetPass(stdin, stdout, "mpd password: ");
+        Log().InfoStr(
+            "Disabling reconnect support since the password was "
+            "provided interactively. Supply password via MPD_HOST "
+            "environment variable to enable automatic "
+            "reconnects");
+        return pass;
     };
+
     /* attempt to connect to MPD */
     absl::StatusOr<std::unique_ptr<mpd::MPD>> mpd =
-        Connect(*mpd::client::Dialer(), options, pass_f);
+        Connect(*mpd::client::Dialer(), options, &pass_f);
     if (!mpd.ok()) {
         Die("Failed to connect to mpd: %s", mpd.status().ToString());
     }
@@ -128,11 +165,39 @@ int main(int argc, const char* argv[]) {
             std::cout << absl::StrFormat(" (%u songs)", number_of_songs);
         }
         std::cout << "." << std::endl;
-    } else {
-        if (auto status = Loop(mpd->get(), &songs, options); !status.ok()) {
-            Die("Failed to loop: %s", status.ToString());
-        }
+        exit(EXIT_SUCCESS);
+        return 0;
     }
 
-    return 0;
+    LoopOnce(mpd->get(), songs, options);
+    if (disable_reconnect) {
+        exit(EXIT_FAILURE);
+    }
+
+    absl::Time disconnect_begin = absl::Now();
+    while ((absl::Now() - disconnect_begin) < kMaxDisconnectedTime) {
+        mpd = Connect(*mpd::client::Dialer(), options, kNonInteractiveGetpass);
+        if (!mpd.ok()) {
+            Log().Error("Failed to reconnect to MPD %s, been waiting %s",
+                        mpd.status().ToString(),
+                        absl::FormatDuration(absl::Now() - disconnect_begin));
+
+            absl::SleepFor(kReconnectWait);
+            continue;
+        }
+
+        if (auto l = Reloader(mpd->get(), options); l.has_value()) {
+            (*l)->Load(&songs);
+            PrintChainLength(std::cout, songs);
+        }
+
+        LoopOnce(mpd->get(), songs, options);
+
+        // Re-set the disconnection timer after we successfully reconnect.
+        disconnect_begin = absl::Now();
+    }
+    Log().Error("Could not reconnect after %s, aborting.",
+                absl::FormatDuration(kMaxDisconnectedTime));
+
+    exit(EXIT_FAILURE);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,11 +25,6 @@
 
 using namespace ashuffle;
 
-// This is the maximum amount of time that ashuffle is allowed to be
-// disconnected from MPD before it exits. This catches cases where the
-// environment changes and it would be impossible for ashuffle to reconnect.
-const absl::Duration kMaxDisconnectedTime = absl::Seconds(10);
-
 // The amount of time to wait between reconnection attempts.
 const absl::Duration kReconnectWait = absl::Milliseconds(250);
 
@@ -175,7 +170,7 @@ int main(int argc, const char* argv[]) {
     }
 
     absl::Time disconnect_begin = absl::Now();
-    while ((absl::Now() - disconnect_begin) < kMaxDisconnectedTime) {
+    while ((absl::Now() - disconnect_begin) < options.tweak.reconnect_timeout) {
         mpd = Connect(*mpd::client::Dialer(), options, kNonInteractiveGetpass);
         if (!mpd.ok()) {
             Log().Error("Failed to reconnect to MPD %s, been waiting %s",
@@ -197,7 +192,7 @@ int main(int argc, const char* argv[]) {
         disconnect_begin = absl::Now();
     }
     Log().Error("Could not reconnect after %s, aborting.",
-                absl::FormatDuration(kMaxDisconnectedTime));
+                absl::FormatDuration(options.tweak.reconnect_timeout));
 
     exit(EXIT_FAILURE);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -88,7 +88,12 @@ int main(int argc, const char* argv[]) {
         exit(EXIT_FAILURE);
     }
 
-    log::SetOutput(std::cerr);
+    if (options.log_file == nullptr) {
+        // By default, log to stderr.
+        log::SetOutput(std::cerr);
+    } else {
+        log::SetOutput(*options.log_file);
+    }
 
     bool disable_reconnect = false;
     std::function<std::string()> pass_f = [&disable_reconnect] {

--- a/src/mpd.h
+++ b/src/mpd.h
@@ -8,6 +8,8 @@
 #include <variant>
 #include <vector>
 
+#include "absl/time/time.h"
+
 #include <mpd/idle.h>
 #include <mpd/status.h>
 #include <mpd/tag.h>
@@ -182,16 +184,16 @@ class Dialer {
    public:
     virtual ~Dialer(){};
 
-    constexpr static unsigned kDefaultTimeout = 25000;  // 25 seconds.
+    constexpr static absl::Duration kDefaultTimeout = absl::Seconds(25);
 
-    typedef std::variant<std::unique_ptr<MPD>, std::string> result;
+    using result = std::variant<std::unique_ptr<MPD>, std::string>;
 
     // Dial connects to the MPD instance at the given Address, optionally,
     // with the given timeout. On success a variant with a unique_ptr to
     // an MPD instance is returned. On failure, a string is returned with
     // a human-readable description of the error.
     virtual result Dial(const Address&,
-                        unsigned timeout_ms = kDefaultTimeout) const = 0;
+                        absl::Duration timeout = kDefaultTimeout) const = 0;
 };
 
 }  // namespace mpd

--- a/src/mpd_client.cc
+++ b/src/mpd_client.cc
@@ -231,7 +231,9 @@ absl::StatusOr<std::unique_ptr<Song>> SongReaderImpl::Next() {
         return absl::OutOfRangeError("song reader done");
     }
     // Moving out of an optional will re-set it to null.
-    return std::move(song_.value());
+    auto out = std::move(song_.value());
+    song_.reset();
+    return out;
 }
 
 bool SongReaderImpl::Done() {

--- a/src/mpd_client.cc
+++ b/src/mpd_client.cc
@@ -389,11 +389,13 @@ class DialerImpl : public Dialer {
     // a human-readable description of the error.
     Dialer::result Dial(
         const Address&,
-        unsigned timeout_ms = Dialer::kDefaultTimeout) const override;
+        absl::Duration timeout = Dialer::kDefaultTimeout) const override;
 };
 
 Dialer::result DialerImpl::Dial(const Address& addr,
-                                unsigned timeout_ms) const {
+                                absl::Duration timeout) const {
+    unsigned timeout_ms =
+        static_cast<unsigned>(absl::ToInt64Milliseconds(timeout));
     /* Create a new connection to mpd */
     struct mpd_connection* mpd =
         mpd_connection_new(addr.host.data(), addr.port, timeout_ms);

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -10,6 +10,7 @@
 #include <mpd/tag.h>
 
 #include "args.h"
+#include "gmock/gmock.h"
 #include "rule.h"
 
 #include "t/helper.h"
@@ -40,6 +41,7 @@ TEST(ParseTest, Empty) {
     EXPECT_TRUE(opts.ruleset.empty()) << "there should be no rules by default";
     EXPECT_EQ(opts.queue_only, 0U);
     EXPECT_THAT(opts.file_in, IsNull());
+    EXPECT_THAT(opts.log_file, IsNull());
     EXPECT_TRUE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 0U);
     EXPECT_EQ(opts.host, std::nullopt);
@@ -96,6 +98,7 @@ TEST(ParseTest, Long) {
             "--only", "5",
             "--no-check",
             "--file", "/dev/zero",
+            "--log-file", "/dev/null",
             "--exclude", "artist", "test artist", "artist", "another one",
             "--queue-buffer", "10",
             "--host", "foo",
@@ -113,6 +116,7 @@ TEST(ParseTest, Long) {
     EXPECT_EQ(opts.ruleset.size(), 1U);
     EXPECT_EQ(opts.queue_only, 5U);
     EXPECT_THAT(opts.file_in, NotNull());
+    EXPECT_THAT(opts.log_file, NotNull());
     EXPECT_FALSE(opts.check_uris);
     EXPECT_EQ(opts.queue_buffer, 10U);
     EXPECT_EQ(opts.host, "foo");

--- a/t/args_test.cc
+++ b/t/args_test.cc
@@ -50,6 +50,7 @@ TEST(ParseTest, Empty) {
     EXPECT_EQ(opts.tweak.play_on_startup, true);
     EXPECT_EQ(opts.tweak.suspend_timeout, absl::ZeroDuration());
     EXPECT_EQ(opts.tweak.exit_on_db_update, false);
+    EXPECT_EQ(opts.tweak.reconnect_timeout, absl::Seconds(10));
 }
 
 TEST(ParseTest, Short) {
@@ -268,6 +269,21 @@ TEST(ParseTest, TweakExitOnDBUpdate) {
     Options opts = std::get<Options>(Options::Parse(
         fake::TagParser(), {"--tweak", "exit-on-db-update=yes"}));
     EXPECT_EQ(opts.tweak.exit_on_db_update, true);
+}
+
+TEST(ParseTest, TweakReconnectTimeout) {
+    std::vector<std::tuple<std::string, absl::Duration>> cases = {
+        {"1s", absl::Seconds(1)},
+        {"1m", absl::Minutes(1)},
+        {"3h", absl::Hours(3)},
+        {"250ms", absl::Milliseconds(250)},
+    };
+
+    for (auto [val, want] : cases) {
+        Options opts = std::get<Options>(Options::Parse(
+            fake::TagParser(), {"--tweak", "reconnect-timeout=" + val}));
+        EXPECT_EQ(opts.tweak.reconnect_timeout, want) << "Case: " << val;
+    }
 }
 
 using ParseFailureParam =

--- a/t/ashuffle_test.cc
+++ b/t/ashuffle_test.cc
@@ -450,7 +450,7 @@ TEST_P(ConnectParamTest, ViaEnv) {
     FakePasswordProvider *pp = pass_f.target<FakePasswordProvider>();
 
     absl::StatusOr<std::unique_ptr<mpd::MPD>> result =
-        Connect(dialer, Options(), pass_f);
+        Connect(dialer, Options(), &pass_f);
     ASSERT_OK(result.status()) << "failed to connect to MPD";
 
     EXPECT_THAT(result->get(),
@@ -478,7 +478,7 @@ TEST_P(ConnectParamTest, ViaFlag) {
     FakePasswordProvider *pp = pass_f.target<FakePasswordProvider>();
 
     absl::StatusOr<std::unique_ptr<mpd::MPD>> result =
-        Connect(dialer, opts, pass_f);
+        Connect(dialer, opts, &pass_f);
     ASSERT_OK(result.status()) << "Failed to connect";
 
     EXPECT_THAT(result->get(),
@@ -542,7 +542,7 @@ TEST(ConnectTest, NoPassword) {
     FakePasswordProvider *pp = pass_f.target<FakePasswordProvider>();
 
     absl::StatusOr<std::unique_ptr<mpd::MPD>> result =
-        Connect(dialer, Options(), pass_f);
+        Connect(dialer, Options(), &pass_f);
     ASSERT_OK(result.status()) << "Failed to connect";
 
     EXPECT_THAT(result->get(),
@@ -573,7 +573,7 @@ TEST(ConnectTest, FlagOverridesEnv) {
     FakePasswordProvider *pp = pass_f.target<FakePasswordProvider>();
 
     absl::StatusOr<std::unique_ptr<mpd::MPD>> result =
-        Connect(dialer, opts, pass_f);
+        Connect(dialer, opts, &pass_f);
     ASSERT_OK(result.status()) << "Failed to connect";
 
     EXPECT_EQ(pp->call_count, 0) << "getpass func should not be called";
@@ -599,7 +599,7 @@ TEST(ConnectDeathTest, BadEnvPassword) {
 
     std::function<std::string()> pass_f = FakePasswordProvider();
 
-    EXPECT_EXIT((void)Connect(dialer, Options(), pass_f), ExitedWithCode(1),
+    EXPECT_EXIT((void)Connect(dialer, Options(), &pass_f), ExitedWithCode(1),
                 HasSubstr("required command still not allowed"));
 }
 
@@ -627,7 +627,7 @@ TEST(ConnectDeathTest, EnvPasswordValidWithNoPermissions) {
     // We should terminate after seeing the bad permissions. If we end up
     // re-prompting (and getting a good password), we should succeed, and fail
     // the test.
-    EXPECT_EXIT((void)Connect(dialer, Options(), pass_f), ExitedWithCode(1),
+    EXPECT_EXIT((void)Connect(dialer, Options(), &pass_f), ExitedWithCode(1),
                 HasSubstr("required command still not allowed"));
 }
 
@@ -654,7 +654,7 @@ TEST(ConnectTest, BadPermsOKPrompt) {
     EXPECT_EQ(pp->call_count, 0);
 
     absl::StatusOr<std::unique_ptr<mpd::MPD>> result =
-        Connect(dialer, Options(), pass_f);
+        Connect(dialer, Options(), &pass_f);
     ASSERT_OK(result.status()) << "Failed to connect";
 
     EXPECT_THAT(result->get(),
@@ -684,7 +684,7 @@ TEST(ConnectDeathTest, BadPermsBadPrompt) {
     std::function<std::string()> pass_f =
         FakePasswordProvider("prompt_password");
 
-    EXPECT_EXIT((void)Connect(dialer, Options(), pass_f), ExitedWithCode(1),
+    EXPECT_EXIT((void)Connect(dialer, Options(), &pass_f), ExitedWithCode(1),
                 HasSubstr("required command still not allowed"));
 }
 

--- a/t/docker/Dockerfile.ubuntu
+++ b/t/docker/Dockerfile.ubuntu
@@ -37,4 +37,7 @@ ENV STAGE_DIR ${STAGE_DIR:-./}
 # is automatically extracted by this rule.
 ADD ${STAGE_DIR}/ashuffle-archive.tar /ashuffle/
 
+RUN cd /ashuffle && \
+    /opt/meta/meta testbuild
+
 ENTRYPOINT ["/exec/run_integration.sh"]

--- a/t/docker/run_integration.sh
+++ b/t/docker/run_integration.sh
@@ -2,5 +2,4 @@
 cd /ashuffle/t/integration
 # The default test timeout is 10m. Need to set the timeout to 1h so the larger
 # performance tests can run.
-# TODO(jkz): Factor out performance tests so they can run in parallel.
 exec go test -v -timeout 1h "$@" ashuffle/integration

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"io/ioutil"
@@ -963,6 +965,7 @@ func TestExclude(t *testing.T) {
 }
 
 func TestReconnect(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	root, err := testmpd.NewRoot(&testmpd.Options{LibraryRoot: "/music"})
@@ -1030,9 +1033,10 @@ func TestReconnect(t *testing.T) {
 	if err := restartMPD.Shutdown(); err != nil {
 		t.Errorf("restart mpd did not shutdown cleanly: %v", err)
 	}
-
 }
+
 func TestReconnect_Timeout(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	as, mpd := run(ctx, t, runOptions{
@@ -1075,5 +1079,104 @@ func TestReconnect_Timeout(t *testing.T) {
 	if !strings.Contains(as.Stderr.String(), wantMsg) {
 		t.Logf("stderr:\n%s", as.Stderr)
 		t.Errorf("ashuffle stderr does not include %q", wantMsg)
+	}
+}
+
+func TestReconnect_PasswordPrompt(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mpd, err := testmpd.New(ctx, &testmpd.Options{
+		LibraryRoot:        "/music",
+		DefaultPermissions: []string{"read"},
+		Passwords: []testmpd.Password{
+			{
+				Password:    "super_secret_mpd_password",
+				Permissions: []string{"read", "add", "control", "admin"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create new MPD instance: %v", err)
+	}
+
+	stdinr, stdinw := io.Pipe()
+	stdoutr, stdoutw := io.Pipe()
+	defer stdoutr.Close()
+	defer stdoutw.Close()
+
+	as, err := testashuffle.New(ctx, ashuffleBin, &testashuffle.Options{
+		MPDAddress:      mpd,
+		Args:            []string{"--tweak", "reconnect-timeout=10s"},
+		Stdin:           stdinr,
+		Stdout:          stdoutw,
+		ShutdownTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("failed to start ashuffle: %v", err)
+	}
+
+	scanStdout := bufio.NewScanner(stdoutr)
+	scanStdout.Split(func(data []byte, _ bool) (int, []byte, error) {
+		idx := bytes.IndexRune(data, ':')
+		if idx < 0 {
+			return 0, nil, nil
+		}
+		return idx, data[:idx+1], nil
+	})
+	for scanStdout.Scan() {
+		if strings.Contains(scanStdout.Text(), "mpd password:") {
+			break
+		}
+	}
+	if err := scanStdout.Err(); err != nil {
+		t.Fatalf("scanner threw error: %v", err)
+	}
+
+	// Make sure that stdout Pipe doesn't block future writes.
+	go io.Copy(io.Discard, stdoutr)
+
+	// Enter the password.
+	if _, err := io.WriteString(stdinw, "super_secret_mpd_password\n"); err != nil {
+		t.Fatalf("failed to write password to ashuffle stdin: %v", err)
+	}
+
+	// Close out stdin now that we've entered our password.
+	stdinr.Close()
+	stdinw.Close()
+
+	// Wait for ashuffle to startup, and start playing a song.
+	tryWaitFor(func() bool { return mpd.PlayState() == testmpd.StatePlay })
+
+	if state := mpd.PlayState(); state != testmpd.StatePlay {
+		t.Errorf("[before shutdown] mpd.PlayState() = %v, want play", state)
+	}
+
+	// Shutdown MPD, ashuffle should remain running. But we won't actually
+	// know till later. Because we entered the password manually this should
+	// immediately exit ashuffle.
+	if err := mpd.Shutdown(); err != nil {
+		t.Fatalf("Failed to shutdown MPD: %v", err)
+	}
+	if !mpd.IsOk() {
+		t.Errorf("MPD had errors: %+v", mpd.Errors)
+	}
+
+	err = as.Shutdown(testashuffle.ShutdownSoft)
+	if err == nil {
+		t.Logf("stdout:\n%s", as.Stdout)
+		t.Logf("stderr:\n%s", as.Stderr)
+		t.Fatalf("ashuffle should have exited with an error, but shutdown cleanly instead")
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Logf("stdout:\n%s", as.Stdout)
+		t.Logf("stderr:\n%s", as.Stderr)
+		t.Fatalf("ashuffle shutdown did not produce exit error, produced %#v", err)
+	}
+
+	if got := exitErr.ExitCode(); got != 1 {
+		t.Errorf("ashuffle exited with code %d, want 1 (full err: %v)", got, err)
 	}
 }

--- a/t/integration/integration/integration_test.go
+++ b/t/integration/integration/integration_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -29,7 +28,7 @@ import (
 )
 
 const (
-	ashuffleBin = "/ashuffle/build/ashuffle"
+	ashuffleBin = "/ashuffle/ashuffle"
 
 	goldMP3 = "/music.huge/gold.mp3"
 )
@@ -136,36 +135,6 @@ func newLibraryT(t *testing.T) *library.Library {
 }
 
 func TestMain(m *testing.M) {
-	// compile ashuffle
-	origDir, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("failed to getcwd: %v", err)
-	}
-
-	if err := os.Chdir("/ashuffle"); err != nil {
-		log.Fatalf("failed to chdir to /ashuffle: %v", err)
-	}
-
-	fmt.Println("===> Running MESON")
-	mesonCmd := exec.Command("meson", "--buildtype=debugoptimized", "build")
-	mesonCmd.Stdout = os.Stdout
-	mesonCmd.Stderr = os.Stderr
-	if err := mesonCmd.Run(); err != nil {
-		log.Fatalf("failed to run meson for ashuffle: %v", err)
-	}
-
-	fmt.Println("===> Building ashuffle")
-	ninjaCmd := exec.Command("ninja", "-C", "build", "ashuffle")
-	ninjaCmd.Stdout = os.Stdout
-	ninjaCmd.Stderr = os.Stderr
-	if err := ninjaCmd.Run(); err != nil {
-		log.Fatalf("failed to build ashuffle: %v", err)
-	}
-
-	if err := os.Chdir(origDir); err != nil {
-		log.Fatalf("failed to reset workdir: %v", err)
-	}
-
 	lib, err := newLibrary()
 	if err != nil {
 		log.Fatalf("failed to create new library: %v", err)
@@ -252,6 +221,8 @@ func TestShuffleOnce(t *testing.T) {
 
 	// Wait for ashuffle to exit.
 	if err := as.Shutdown(testashuffle.ShutdownSoft); err != nil {
+		t.Logf("stderr: %s", as.Stderr)
+		t.Logf("stdout: %s", as.Stdout)
 		t.Errorf("ashuffle did not shut down cleanly: %v", err)
 	}
 

--- a/t/integration/testmpd/testmpd.go
+++ b/t/integration/testmpd/testmpd.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -135,7 +136,7 @@ type MPD struct {
 	// Stderr is a buffer that contains the standard error of the MPD process.
 	Stderr *bytes.Buffer
 
-	root       root
+	root       Root
 	cmd        *exec.Cmd
 	cli        *mpdc.Client
 	cancelFunc func()
@@ -154,7 +155,7 @@ func (m MPD) Address() (string, string) {
 
 // Shutdown shuts down this MPD instance, and cleans up associated data.
 func (m *MPD) Shutdown() error {
-	defer m.root.cleanup()
+	defer m.root.Cleanup()
 	m.cli.Close()
 
 	// Shutdown the server, either via SIGTERM, or by cancelling the
@@ -282,17 +283,37 @@ func (m *MPD) PlayState() State {
 	return StateUnknown
 }
 
-type root struct {
+// A Root represents the state required to run an instance of MPD.
+type Root struct {
 	path     string
 	socket   string
 	confPath string
+	options  *Options
+
+	// Set to true if this root is owned by the MPD instance. If set to
+	// false it will not be cleaned up when the MPD instance is destroyed.
+	owned bool
+
+	cleanupOnce sync.Once
 }
 
-func (r root) cleanup() {
-	os.RemoveAll(r.path)
+// Cleanup any state associated with this root. Should be called when
+// the root is no longer needed.
+func (r *Root) Cleanup() {
+	// We only want to do this once per-root. Future cleanups should be
+	// no-ops.
+	r.cleanupOnce.Do(func() {
+		os.RemoveAll(r.path)
+	})
 }
 
-func buildRoot(opts *Options) (*root, error) {
+func (r Root) hasOptions() bool {
+	return r.options != nil
+}
+
+// Create a new Root. The caller is expected to call Root.Cleanup when its
+// done using the root.
+func NewRoot(opts *Options) (*Root, error) {
 	rootPath, err := ioutil.TempDir(os.TempDir(), "mpd-harness")
 	if err != nil {
 		return nil, err
@@ -309,35 +330,49 @@ func buildRoot(opts *Options) (*root, error) {
 		return nil, err
 	}
 	conf.Close()
-	return &root{
+	return &Root{
 		path:     rootPath,
 		socket:   mpdSocket,
 		confPath: confPath,
+		options:  opts,
 	}, nil
+}
+
+func New(ctx context.Context, opts *Options) (*MPD, error) {
+	root, err := NewRoot(opts)
+	if err != nil {
+		return nil, err
+	}
+	// We created this root, so we take ownership of its lifecycle.
+	root.owned = true
+	return NewWithRoot(ctx, root)
 }
 
 // New creates a new MPD instance with the given options. If `opts' is nil,
 // then default options will be used. If a new MPD instance cannot be created,
 // an error is returned.
-func New(ctx context.Context, opts *Options) (*MPD, error) {
-	root, err := buildRoot(opts)
-	if err != nil {
-		return nil, err
-	}
-
+func NewWithRoot(ctx context.Context, root *Root) (*MPD, error) {
 	mpdCtx, mpdCancel := context.WithCancel(ctx)
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 	mpdBin := "mpd"
-	if opts != nil && opts.BinPath != "" {
-		mpdBin = opts.BinPath
+	if root.hasOptions() && root.options.BinPath != "" {
+		mpdBin = root.options.BinPath
 	}
 	cmd := exec.CommandContext(mpdCtx, mpdBin, "--no-daemon", "--stderr", root.confPath)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Start(); err != nil {
+
+	earlyExitCleanup := func() {
 		mpdCancel()
-		root.cleanup()
+		// We only cleanup the root if we own it.
+		if root.owned {
+			root.Cleanup()
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		earlyExitCleanup()
 		return nil, err
 	}
 
@@ -348,7 +383,7 @@ func New(ctx context.Context, opts *Options) (*MPD, error) {
 	connectBackoff := backoff.WithContext(backoff.NewConstantBackOff(mpdConnectBackoff), connectCtx)
 
 	var cli *mpdc.Client
-	err = backoff.Retry(func() error {
+	err := backoff.Retry(func() error {
 		onceCli, err := mpdc.Dial("unix", root.socket)
 		if err != nil {
 			return err
@@ -357,22 +392,16 @@ func New(ctx context.Context, opts *Options) (*MPD, error) {
 		return nil
 	}, connectBackoff)
 	if err != nil {
-		mpdCancel()
+		earlyExitCleanup()
 		return nil, fmt.Errorf("failed to connect to mpd at %s: %v", root.socket, err)
 	}
 	if cli == nil {
 		panic("backoff did not return an error. This should not happen.")
 	}
 
-	if err != nil {
-		mpdCancel()
-		root.cleanup()
-		return nil, err
-	}
-
 	updateTimeout := mpdUpdateDBMax
-	if opts != nil && opts.UpdateDBTimeout != 0 {
-		updateTimeout = opts.UpdateDBTimeout
+	if root.hasOptions() && root.options.UpdateDBTimeout != 0 {
+		updateTimeout = root.options.UpdateDBTimeout
 	}
 
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
@@ -390,8 +419,7 @@ func New(ctx context.Context, opts *Options) (*MPD, error) {
 
 	}, updateBackoff)
 	if err != nil {
-		mpdCancel()
-		root.cleanup()
+		earlyExitCleanup()
 		return nil, fmt.Errorf("failed to wait for MPD db to update: %v", err)
 	}
 

--- a/t/log_test.cc
+++ b/t/log_test.cc
@@ -1,0 +1,37 @@
+#include <sstream>
+
+#include "log.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ashuffle;
+
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+
+auto location_matchers = std::vector({
+    HasSubstr("log_test.cc"),
+    HasSubstr("TestBody"),
+    HasSubstr("test message"),
+});
+
+TEST(LogTest, Info) {
+    std::stringstream out;
+    log::SetOutput(out);
+    Log().Info("test message");
+
+    // 22 is the line number we expect to be logged.
+    EXPECT_THAT(out.str(), AllOf(HasSubstr("INFO"), HasSubstr("22"),
+                                 AllOfArray(location_matchers)));
+}
+
+TEST(LogTest, Error) {
+    std::stringstream out;
+    log::SetOutput(out);
+    Log().Error("test message");
+
+    // 32 is the line number we expect to be logged.
+    EXPECT_THAT(out.str(), AllOf(HasSubstr("ERROR"), HasSubstr("32"),
+                                 AllOfArray(location_matchers)));
+}

--- a/t/mpd_fake.h
+++ b/t/mpd_fake.h
@@ -343,7 +343,7 @@ class Dialer : public mpd::Dialer {
     mpd::Address check;
 
     mpd::Dialer::result Dial(const mpd::Address& addr,
-                             __attribute__((unused)) unsigned timeout_ms =
+                             __attribute__((unused)) absl::Duration timeout =
                                  mpd::Dialer::kDefaultTimeout) const override {
         std::string got = absl::StrFormat("%s:%d", addr.host, addr.port);
         std::string want = absl::StrFormat("%s:%d", check.host, check.port);

--- a/t/test_asserts.h
+++ b/t/test_asserts.h
@@ -1,0 +1,9 @@
+#ifndef __ASHUFFLE_T_TEST_ASSERTS_H__
+#define __ASHUFFLE_T_TEST_ASSERTS_H__
+
+#include <iostream>
+
+// Assert that the given status is OK, or print the bad status.
+#define ASSERT_OK(x) ASSERT_TRUE((x).ok()) << "Bad status: " << (x)
+
+#endif  // __ASHUFFLE_T_TEST_ASSERTS_H__

--- a/tools/meta/commands/testbuild/testbuild.go
+++ b/tools/meta/commands/testbuild/testbuild.go
@@ -1,0 +1,66 @@
+package testbuild
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+
+	"meta/fileutil"
+	"meta/project"
+	"meta/workspace"
+)
+
+func testbuild(ctx *cli.Context) error {
+	out := ctx.String("output")
+	if out == "" {
+		o, err := filepath.Abs("./ashuffle")
+		if err != nil {
+			return err
+		}
+		out = o
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	build, err := workspace.New(workspace.NoCD)
+	if err != nil {
+		return err
+	}
+	defer build.Cleanup()
+
+	p, err := project.NewMeson(cwd, project.MesonOptions{
+		BuildType:      project.BuildDebugOptimized,
+		BuildDirectory: build.Root,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := p.Configure(""); err != nil {
+		return err
+	}
+
+	if err := p.Build("ashuffle"); err != nil {
+		return err
+	}
+
+	return fileutil.Copy(build.Path("ashuffle"), out)
+}
+
+var Command = &cli.Command{
+	Name:  "testbuild",
+	Usage: "Build ashuffle for integration tests.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Value:   "",
+			Usage:   "If set, the built binary will be written to this location.",
+		},
+	},
+	Action: testbuild,
+}

--- a/tools/meta/meta.go
+++ b/tools/meta/meta.go
@@ -10,6 +10,7 @@ import (
 	"meta/commands/libmpdclient"
 	"meta/commands/mpd"
 	"meta/commands/release"
+	"meta/commands/testbuild"
 )
 
 func doLibmpdclient(ctx *cli.Context) error {
@@ -34,6 +35,7 @@ func main() {
 				},
 			},
 			release.Command,
+			testbuild.Command,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/tools/meta/project/project.go
+++ b/tools/meta/project/project.go
@@ -79,6 +79,8 @@ func (m MesonBuildType) flag() string {
 	return "--buildtype=" + m.String()
 }
 
+type Env map[string]string
+
 type MesonOptions struct {
 	// BuildType the build type (essentially optimization level) to perform.
 	BuildType MesonBuildType
@@ -88,6 +90,9 @@ type MesonOptions struct {
 	// Extra provides additional flags that should be provided to meson as
 	// part of the configure step.
 	Extra []string
+	// Environment contains additional environment variables that will be
+	// supplied to meson during the configuration step.
+	Environment Env
 }
 
 // Meson represents a meson project.
@@ -110,6 +115,11 @@ func (m *Meson) Configure(dest string) error {
 		".", m.opts.BuildDirectory,
 		m.opts.BuildType.flag(),
 	)
+	env := os.Environ()
+	for k, v := range m.opts.Environment {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	cmd.Env = env
 	if dest != "" {
 		cmd.Args = append(cmd.Args, "--prefix="+dest)
 	}


### PR DESCRIPTION
This change addresses #98 by automatically attempting to reconnect to MPD after a temporary disconnection. It should be backwards compatible with all existing features, and should not require a major version cut.