### PR TITLE
Fix detection of header-only absl components

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,7 @@ else
   # note that the system's absl needs to be compiled for C++17 standard
   # or final link will fail.
   foreach lib : absl_libs
-    dep = cpp.find_library(lib)
+    dep = dependency(lib)
     if dep.found()
       absl_deps += dep
     endif


### PR DESCRIPTION
Fix detection of header-only absl components 
in unsupported_use_system_absl mode by switching from cpp.find_library() to dependency().
The former is not able to find header-only components, 
since they do not have any *.so or *.a file associated with them. 
dependency() relies on pkg-config, which works fine in this case.

I tested with abseil-cpp `20230125` package on Arch Linux which does have the neccessary `*.pc` files for pkg-config.
I think some older abseil packages (`2020*` versions and older) do not have them, like the libabsl-dev package in Debian 11 bullseye,
but they'll always be able to use the bundled mode instead of the system's package.
All `2021*` versions and newer I looked at, did have the files. ([1] [2] [3])
And those old `2020*` versions are probably way too old for ashuffle anyway.


Before:
```
meson.build:126:14: ERROR: C++ shared or static library 'absl_cordz_update_tracker' not found
```
After:
```
Run-time dependency absl_cordz_update_tracker found: YES 20230125
```

[1]: https://packages.debian.org/bookworm/libabsl-dev
[2]: https://packages.ubuntu.com/jammy/libabsl-dev
[3]: https://packages.fedoraproject.org/pkgs/abseil-cpp/abseil-cpp-devel/
