### PR TITLE
Fix non build for non-standard MPD header locations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -172,7 +172,7 @@ libashuffle = static_library(
   'ashuffle',
   sources,
   include_directories: src_inc,
-  dependencies: absl_deps + [yaml_cpp],
+  dependencies: absl_deps + [yaml_cpp, libmpdclient],
 )
 
 ashuffle = executable(

--- a/src/ashuffle.h
+++ b/src/ashuffle.h
@@ -22,7 +22,7 @@ namespace ashuffle {
 namespace {
 
 // A getpass_f value that can be used in non-interactive mode.
-std::function<std::string()>* kNonInteractiveGetpass = nullptr;
+[[maybe_unused]] std::function<std::string()>* kNonInteractiveGetpass = nullptr;
 
 }  // namespace
 


### PR DESCRIPTION
Right now, the build depends on the MPD headers (presumably coming from libmpdclient) being in a system directory. This PR fixes the build configuration, so even non-system installs will work as long as they are discoverable with pkg-config.

Fixes #226 