### PR TITLE
Speed up CI build and integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,56 @@ jobs:
         env:
           SANITIZER: ${{ matrix.sanitizer }}
         run: scripts/github/unit-test
+  build-integration-test-images:
+    strategy:
+      matrix:
+        target:
+          - name: "Latest"
+            libmpdclient_version: "latest"
+            mpd_version: "latest"
+          - name: "Bionic"
+            libmpdclient_version: "2.11"
+            mpd_version: "0.20.18"
+          - name: "Focal"
+            libmpdclient_version: "2.18"
+            mpd_version: "0.21.20"
+          - name: "Impish"
+            libmpdclient_version: "2.19"
+            mpd_version: "0.22.6"
+    name: "Build ${{ matrix.target.name }} Integration Test Container"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # This whole little song and dance is pretty annoying. Ideally I could
+      # just use ./scripts/run-integration and be done with it, but to get
+      # caching, I need to use the build-push-action. This is because gha
+      # only exposes the necessary values to the node runtime, not via a script
+      # consumable mechanism. There is a bug out for this, so hopefully this
+      # can all be deleted eventually: https://github.com/actions/runner/issues/3046
+      #
+      # We still need to run "build-test-image" here to do the little tarring
+      # step. Maybe I can delete that, and just go straight to build-push-action?
+      - name: Stage Build
+        id: stage
+        env:
+          MPD_VERSION: ${{ matrix.target.mpd_version }}
+          LIBMPDCLIENT_VERSION: ${{ matrix.target.libmpdclient_version }}
+        run: |
+          git submodule update --init --recursive
+          # produces the outputs used in the subseqent step
+          scripts/github/resolve-versions
+      - name: Build Integration Test Container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: t/docker/Dockerfile.ubuntu
+          build-args: |
+            LIBMPDCLIENT_VERSION=${{ steps.stage.outputs.LIBMPDCLIENT_VERSION }}
+            MPD_VERSION=${{ steps.stage.outputs.MPD_VERSION }}
+          tags: test/ashuffle:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   integration-test:
     strategy:
       matrix:
@@ -77,8 +127,10 @@ jobs:
             args: "-run 'TestFastStartup/from.mpd,.group-by'"
     name: "Integration Test (${{ matrix.target.name }}): ${{ matrix.test_group.name }}"
     runs-on: ubuntu-latest
-    needs: [check-format, check-lint, unit-test]
+    needs: [check-format, check-lint, unit-test, build-integration-test-images]
     steps:
+      # this is a replay of the build-container steps, but since those ran
+      # previously, this should be fully cached.
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       # This whole little song and dance is pretty annoying. Ideally I could
@@ -111,6 +163,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           load: true
+      # This is the actual new work, running the actual test.
       - name: Run Test
         run: |
           scripts/run-integration \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
           cache-dependency-path: tools/meta/go.sum
@@ -136,7 +136,7 @@ jobs:
       # this is a replay of the build-container steps, but since those ran
       # previously, this should be fully cached.
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
           cache-dependency-path: tools/meta/go.sum

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,8 +96,8 @@ jobs:
             LIBMPDCLIENT_VERSION=${{ steps.stage.outputs.LIBMPDCLIENT_VERSION }}
             MPD_VERSION=${{ steps.stage.outputs.MPD_VERSION }}
           tags: test/ashuffle:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.target.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target.name }}
   integration-test:
     strategy:
       matrix:
@@ -168,8 +168,8 @@ jobs:
             LIBMPDCLIENT_VERSION=${{ steps.stage.outputs.LIBMPDCLIENT_VERSION }}
             MPD_VERSION=${{ steps.stage.outputs.MPD_VERSION }}
           tags: test/ashuffle:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.target.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target.name }}
           load: true
       # This is the actual new work, running the actual test.
       - name: Run Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,6 @@ jobs:
             name_suffix: " (ASAN)"
     name: Unit Test${{ matrix.name_suffix }}
     runs-on: ubuntu-latest
-    needs: [check-format, check-lint]
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -78,7 +77,7 @@ jobs:
             args: "-run 'TestFastStartup/from.mpd,.group-by'"
     name: "Integration Test (${{ matrix.target.name }}): ${{ matrix.test_group.name }}"
     runs-on: ubuntu-latest
-    needs: [unit-test]
+    needs: [check-format, check-lint, unit-test]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,8 @@ jobs:
           LIBMPDCLIENT_VERSION: ${{ matrix.target.libmpdclient_version }}
         run: |
           git submodule update --init --recursive
-          scripts/build-test-image --for-github-workflow
+          # produces the outputs used in the subseqent step
+          scripts/github/resolve-versions
       - name: Build Integration Test Container
         uses: docker/build-push-action@v5
         with:
@@ -107,7 +108,6 @@ jobs:
           build-args: |
             LIBMPDCLIENT_VERSION=${{ steps.stage.outputs.LIBMPDCLIENT_VERSION }}
             MPD_VERSION=${{ steps.stage.outputs.MPD_VERSION }}
-            STAGE_DIR=${{ steps.stage.outputs.STAGE_DIR }}
           tags: test/ashuffle:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,15 +80,43 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-test]
     steps:
-      - name: Clone
-        uses: actions/checkout@v4
-      - name: Integration Test
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      # This whole little song and dance is pretty annoying. Ideally I could
+      # just use ./scripts/run-integration and be done with it, but to get
+      # caching, I need to use the build-push-action. This is because gha
+      # only exposes the necessary values to the node runtime, not via a script
+      # consumable mechanism. There is a bug out for this, so hopefully this
+      # can all be deleted eventually: https://github.com/actions/runner/issues/3046
+      #
+      # We still need to run "build-test-image" here to do the little tarring
+      # step. Maybe I can delete that, and just go straight to build-push-action?
+      - name: Stage Build
+        id: stage
         env:
           MPD_VERSION: ${{ matrix.target.mpd_version }}
           LIBMPDCLIENT_VERSION: ${{ matrix.target.libmpdclient_version }}
         run: |
           git submodule update --init --recursive
-          scripts/run-integration --no_tty ${{ matrix.test_group.args }}
+          scripts/build-test-image --for-github-workflow
+      - name: Build Integration Test Container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: t/docker/Dockerfile.ubuntu
+          build-args: |
+            LIBMPDCLIENT_VERSION=${{ steps.stage.outputs.LIBMPDCLIENT_VERSION }}
+            MPD_VERSION=${{ steps.stage.outputs.MPD_VERSION }}
+            STAGE_DIR=${{ steps.stage.outputs.STAGE_DIR }}
+          tags: test/ashuffle:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+      - name: Run Test
+        run: |
+          scripts/run-integration \
+          --no_build_use_image=test/ashuffle:latest \
+          --no_tty ${{ matrix.test_group.args }}
   release-build:
     name: Release Build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -178,16 +178,43 @@ jobs:
           --no_build_use_image=test/ashuffle:latest \
           --no_tty ${{ matrix.test_group.args }}
   release-build:
-    name: Release Build
+    name: Release Build (${{ matrix.target.arch }})
     runs-on: ubuntu-latest
-    needs: [integration-test]
+    needs: [check-format, check-lint, unit-test]
+    strategy:
+      matrix:
+        target:
+          - arch: "x86_64"
+            triple: "x86_64-linux-gnu"
+          - arch: "aarch64"
+            triple: "aarch64-linux-gnu"
+          - arch: "armv6h"
+            triple: "armv6h-linux-gnueabihf"
+          - arch: "armv7h"
+            triple: "armv7h"
     steps:
       - name: Clone
         uses: actions/checkout@v4
       - name: Release Build
-        run: scripts/github/release
+        run: scripts/github/release ashuffle.${{ matrix.target.triple }} ${{ matrix.target.arch }}
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ashuffle.${{ matrix.target.triple }}
+          path: ashuffle.${{ matrix.target.triple }}
+          if-no-files-found: error
+          retention-days: 7
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [release-build, integration-test]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download Builds
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "ashuffle.*"
       - name: Deploy
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref }}
@@ -199,7 +226,7 @@ jobs:
             --title "${tag}" \
             --generate-notes \
             "${tag}" \
-            release/ashuffle.x86_64-linux-gnu \
-            release/ashuffle.aarch64-linux-gnu \
-            release/ashuffle.armv7h-linux-gnueabihf \
-            release/ashuffle.armv6h-linux-gnueabihf
+            ashuffle.x86_64-linux-gnu \
+            ashuffle.aarch64-linux-gnu \
+            ashuffle.armv7h-linux-gnueabihf \
+            ashuffle.armv6h-linux-gnueabihf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,6 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+          cache-dependency-path: tools/meta/go.sum
       - uses: docker/setup-buildx-action@v3
       # This whole little song and dance is pretty annoying. Ideally I could
       # just use ./scripts/run-integration and be done with it, but to get
@@ -132,6 +136,10 @@ jobs:
       # this is a replay of the build-container steps, but since those ran
       # previously, this should be fully cached.
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+          cache-dependency-path: tools/meta/go.sum
       - uses: docker/setup-buildx-action@v3
       # This whole little song and dance is pretty annoying. Ideally I could
       # just use ./scripts/run-integration and be done with it, but to get

--- a/meson.build
+++ b/meson.build
@@ -183,9 +183,16 @@ ashuffle = executable(
   install: true,
 )
 
-clang_tidy = run_target('ashuffle-clang-tidy',
-  command : files('scripts/run-clang-tidy') + sources + executable_sources
-)
+fs = import('fs')
+
+if fs.exists('scripts/run-clang-tidy')
+  # In the integration test container, we don't supply this script for caching
+  # reasons, but this fails the build. So we make this target conditional
+  # on the script being present.
+  clang_tidy = run_target('ashuffle-clang-tidy',
+    command : files('scripts/run-clang-tidy') + sources + executable_sources
+  )
+endif # clang-tidy
 
 if get_option('tests').enabled()
 

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-TEMPDIR="./tmp"
 IMAGE_BASE=ubuntu
 
 function die() {
@@ -60,24 +59,6 @@ done
 
 cd $(git rev-parse --show-toplevel)
 
-mkdir "${TEMPDIR}"
-STAGE_DIR=$(mktemp -p "${TEMPDIR}" --directory)
-if test ! -d "${STAGE_DIR}"; then
-    rm -r "${TEMPDIR}"
-    die "Failed to create staging directory"
-fi
-
-function repo_files() {
-    # Why on earth git does not use the standard exlude rules for ls-files is
-    # beyond me.
-    # Note: We need the sort -u here because files may be repeated if they are
-    # modified in the repo.
-    git ls-files --exclude-standard -cmo | sort -u
-}
-
-echo "Building ashuffle archive..."
-tar -cf "${STAGE_DIR}/ashuffle-archive.tar" --files-from=<( repo_files )
-
 case "${IMAGE_BASE}" in
     ubuntu)
         args=( "${DOCKER_ARGS[@]}" )
@@ -87,15 +68,8 @@ case "${IMAGE_BASE}" in
         if test -n "${LIBMPDCLIENT_VERSION}"; then
             args+=( "--build-arg" "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" )
         fi
-        docker build "${args[@]}" --build-arg "STAGE_DIR=${STAGE_DIR}" \
+        docker build "${args[@]}" \
             -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.ubuntu .
-        ;;
-    alpine)
-        if test -n "${MPD_VERSION}" || test -n "${LIBMPDCLIENT_VERSION}"; then
-            die "alpine does not support setting mpd/libmpdclient version"
-        fi
-        docker build --build-arg "STAGE_DIR=${STAGE_DIR}" \
-            -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.alpine .
         ;;
     github-workflows)
         echo "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"
@@ -105,8 +79,3 @@ case "${IMAGE_BASE}" in
     *)
         die "invalid image base: ${IMAGE_BASE}"
 esac
-
-if [[ "${IMAGE_BASE}" != "github-workflows" ]]; then
-    rm -r "${STAGE_DIR}"
-    rmdir --ignore-fail-on-non-empty "${TEMPDIR}"
-fi

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE_BASE=ubuntu
+set -euo pipefail
 
 function die() {
     echo "$@" >&2
@@ -16,7 +16,6 @@ Arguments:
     -m, --mpd-version           Use the given version of MPD.
     -l, --libmpdclient-version  Use the given version of libmpdclient.
     -t, --image-tag             Use the given tag for the built image.
-    --for-github-workflow       Only output properties to step output file.
                                 Used as part of the github workflow.
 Any remaining arguments ([...]) are passed to docker.
 EOF
@@ -46,10 +45,6 @@ while test "$#" -gt 0; do
             IMAGE_TAG="$2"
             shift 2
             ;;
-        --for-github-workflow)
-            IMAGE_BASE="github-workflows"
-            shift
-            ;;
         *)
             DOCKER_ARGS+=( "$1" )
             shift
@@ -59,23 +54,12 @@ done
 
 cd $(git rev-parse --show-toplevel)
 
-case "${IMAGE_BASE}" in
-    ubuntu)
-        args=( "${DOCKER_ARGS[@]}" )
-        if test -n "${MPD_VERSION}"; then
-            args+=( "--build-arg" "MPD_VERSION=${MPD_VERSION}" )
-        fi
-        if test -n "${LIBMPDCLIENT_VERSION}"; then
-            args+=( "--build-arg" "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" )
-        fi
-        docker build "${args[@]}" \
-            -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.ubuntu .
-        ;;
-    github-workflows)
-        echo "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"
-        echo "MPD_VERSION=${MPD_VERSION}" >> "${GITHUB_OUTPUT}"
-        echo "STAGE_DIR=${STAGE_DIR}" >> "${GITHUB_OUTPUT}"
-        ;;
-    *)
-        die "invalid image base: ${IMAGE_BASE}"
-esac
+args=( "${DOCKER_ARGS[@]}" )
+if test -n "${MPD_VERSION}"; then
+    args+=( "--build-arg" "MPD_VERSION=${MPD_VERSION}" )
+fi
+if test -n "${LIBMPDCLIENT_VERSION}"; then
+    args+=( "--build-arg" "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" )
+fi
+docker build "${args[@]}" \
+    -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.ubuntu .

--- a/scripts/build-test-image
+++ b/scripts/build-test-image
@@ -17,6 +17,8 @@ Arguments:
     -m, --mpd-version           Use the given version of MPD.
     -l, --libmpdclient-version  Use the given version of libmpdclient.
     -t, --image-tag             Use the given tag for the built image.
+    --for-github-workflow       Only output properties to step output file.
+                                Used as part of the github workflow.
 Any remaining arguments ([...]) are passed to docker.
 EOF
     exit 1
@@ -44,6 +46,10 @@ while test "$#" -gt 0; do
         -t|--image-tag)
             IMAGE_TAG="$2"
             shift 2
+            ;;
+        --for-github-workflow)
+            IMAGE_BASE="github-workflows"
+            shift
             ;;
         *)
             DOCKER_ARGS+=( "$1" )
@@ -91,9 +97,16 @@ case "${IMAGE_BASE}" in
         docker build --build-arg "STAGE_DIR=${STAGE_DIR}" \
             -t "${IMAGE_TAG}" -f ./t/docker/Dockerfile.alpine .
         ;;
+    github-workflows)
+        echo "LIBMPDCLIENT_VERSION=${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "MPD_VERSION=${MPD_VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "STAGE_DIR=${STAGE_DIR}" >> "${GITHUB_OUTPUT}"
+        ;;
     *)
         die "invalid image base: ${IMAGE_BASE}"
 esac
 
-rm -r "${STAGE_DIR}"
-rmdir --ignore-fail-on-non-empty "${TEMPDIR}"
+if [[ "${IMAGE_BASE}" != "github-workflows" ]]; then
+    rm -r "${STAGE_DIR}"
+    rmdir --ignore-fail-on-non-empty "${TEMPDIR}"
+fi

--- a/scripts/github/common.sh
+++ b/scripts/github/common.sh
@@ -1,9 +1,6 @@
 # renovate: datasource=pypi depName=meson
 MESON_VERSION="1.3.1"
-# renovate: datasource=github-tags depName=golang/go
-GO_VERSION="go1.20.1"
 LLVM_RELEASE="14"
-GIMMIE_URL="https://raw.githubusercontent.com/travis-ci/gimme/master/gimme"
 
 CLANG_CC="clang-${LLVM_RELEASE}"
 CLANG_CXX="clang++-${LLVM_RELEASE}"
@@ -16,19 +13,8 @@ die() {
     exit 1
 }
 
-install_go() {
-    local want_ver="${GO_VERSION}"
-    if test $# -gt 0; then
-        want_ver="$1"
-    fi
-    # Sed out the 'go...' prefix.
-    goversion="$(echo "${want_ver}" | sed -E 's/^go(.*)/\1/')"
-    # Gimmie outputs envrionment variables, so we need to eval them here.
-    eval "$(curl -sL "${GIMMIE_URL}" | GIMME_GO_VERSION="${goversion}" bash)"
-}
-
 build_meta() {
-    (cd tools/meta && GO11MODULE=on go build)
+    (cd tools/meta && GO11MODULE=on go build -o "${RUNNER_TEMP}/meta")
 }
 
 setup() {
@@ -48,6 +34,4 @@ setup() {
             python3 python3-pip python3-setuptools python3-wheel \
     || die "couldn't apt-get required packages"
     sudo pip3 install meson=="${MESON_VERSION}" || die "couldn't install meson"
-    install_go "${GO_VERSION}"
-    build_meta
 }

--- a/scripts/github/common.sh
+++ b/scripts/github/common.sh
@@ -17,8 +17,12 @@ die() {
 }
 
 install_go() {
+    local want_ver="${GO_VERSION}"
+    if test $# -gt 0; then
+        want_ver="$1"
+    fi
     # Sed out the 'go...' prefix.
-    goversion="$(echo "$1" | sed -E 's/^go(.*)/\1/')"
+    goversion="$(echo "${want_ver}" | sed -E 's/^go(.*)/\1/')"
     # Gimmie outputs envrionment variables, so we need to eval them here.
     eval "$(curl -sL "${GIMMIE_URL}" | GIMME_GO_VERSION="${goversion}" bash)"
 }
@@ -42,7 +46,7 @@ setup() {
             ninja-build \
             patchelf \
             python3 python3-pip python3-setuptools python3-wheel \
-    || die "couldn't apt-get required packages" 
+    || die "couldn't apt-get required packages"
     sudo pip3 install meson=="${MESON_VERSION}" || die "couldn't install meson"
     install_go "${GO_VERSION}"
     build_meta

--- a/scripts/github/common.sh
+++ b/scripts/github/common.sh
@@ -18,7 +18,7 @@ build_meta() {
 }
 
 setup() {
-    if test -n "${IN_DEBUG_MODE}"; then
+    if test -n "${IN_DEBUG_MODE:-}"; then
         return 0
     fi
     sudo env DEBIAN_FRONTEND=noninteractive apt-get update -y && \

--- a/scripts/github/release
+++ b/scripts/github/release
@@ -28,23 +28,34 @@ assure_format() {
     return 0
 }
 
-meta() {
-    "${RUNNER_TEMP}/meta" "$@"
-}
+OUT="$1"
+ARCH="$2"
 
-mkdir -p release
-meta release -o release/ashuffle.x86_64-linux-gnu x86_64 &
-meta release -o release/ashuffle.aarch64-linux-gnu \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" aarch64 &
-meta release -o release/ashuffle.armv7h-linux-gnueabihf \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv7h &
-meta release -o release/ashuffle.armv6h-linux-gnueabihf \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv6h &
+cross_args=()
+check_arch=""
+case "${ARCH}" in
+    x86_64)
+        check_arch="X86-64"
+        ;;
+    aarch64)
+        check_arch="AArch64"
+        cross_args=(
+            --cross_cc="${CLANG_CC}"
+            --cross_cxx="${CLANG_CXX}"
+        )
+        ;;
+    arm*)
+        check_arch="ARM"
+        cross_args=(
+            --cross_cc="${CLANG_CC}"
+            --cross_cxx="${CLANG_CXX}"
+        )
+        ;;
+    *)
+        die "unrecognized arch ${ARCH}"
+        ;;
+esac
 
-# Wait for all the builds to complete.
-wait
+"${RUNNER_TEMP}/meta" release -o "${OUT}" "${cross_args[@]}" "${ARCH}"
 
-assure_format release/ashuffle.x86_64-linux-gnu X86-64
-assure_format release/ashuffle.aarch64-linux-gnu AArch64
-assure_format release/ashuffle.armv7h-linux-gnueabihf ARM
-assure_format release/ashuffle.armv6h-linux-gnueabihf ARM
+assure_format "${OUT}" "${check_arch}"

--- a/scripts/github/release
+++ b/scripts/github/release
@@ -2,6 +2,7 @@
 
 . "scripts/github/common.sh"
 
+build_meta
 setup
 
 assure_format() {
@@ -25,15 +26,19 @@ assure_format() {
     return 0
 }
 
+meta() {
+    "${RUNNER_TEMP}/meta" "$@"
+}
+
 mkdir -p release
-tools/meta/meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
+meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
 assure_format release/ashuffle.x86_64-linux-gnu X86-64
-tools/meta/meta release -o release/ashuffle.aarch64-linux-gnu \
+meta release -o release/ashuffle.aarch64-linux-gnu \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" aarch64 || die "couldn't build aarch64"
 assure_format release/ashuffle.aarch64-linux-gnu AArch64
-tools/meta/meta release -o release/ashuffle.armv7h-linux-gnueabihf \
+meta release -o release/ashuffle.armv7h-linux-gnueabihf \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv7h || die "couldn't build armv7h"
 assure_format release/ashuffle.armv7h-linux-gnueabihf ARM
-tools/meta/meta release -o release/ashuffle.armv6h-linux-gnueabihf \
+meta release -o release/ashuffle.armv6h-linux-gnueabihf \
     --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv6h || die "couldn't build armv6h"
 assure_format release/ashuffle.armv6h-linux-gnueabihf ARM

--- a/scripts/github/release
+++ b/scripts/github/release
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 . "scripts/github/common.sh"
 
 build_meta
@@ -31,14 +33,18 @@ meta() {
 }
 
 mkdir -p release
-meta release -o release/ashuffle.x86_64-linux-gnu x86_64 || die "couldn't build x86_64"
-assure_format release/ashuffle.x86_64-linux-gnu X86-64
+meta release -o release/ashuffle.x86_64-linux-gnu x86_64 &
 meta release -o release/ashuffle.aarch64-linux-gnu \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" aarch64 || die "couldn't build aarch64"
-assure_format release/ashuffle.aarch64-linux-gnu AArch64
+    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" aarch64 &
 meta release -o release/ashuffle.armv7h-linux-gnueabihf \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv7h || die "couldn't build armv7h"
-assure_format release/ashuffle.armv7h-linux-gnueabihf ARM
+    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv7h &
 meta release -o release/ashuffle.armv6h-linux-gnueabihf \
-    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv6h || die "couldn't build armv6h"
+    --cross_cc="${CLANG_CC}" --cross_cxx="${CLANG_CXX}" armv6h &
+
+# Wait for all the builds to complete.
+wait
+
+assure_format release/ashuffle.x86_64-linux-gnu X86-64
+assure_format release/ashuffle.aarch64-linux-gnu AArch64
+assure_format release/ashuffle.armv7h-linux-gnueabihf ARM
 assure_format release/ashuffle.armv6h-linux-gnueabihf ARM

--- a/scripts/github/resolve-versions
+++ b/scripts/github/resolve-versions
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+. "scripts/github/common.sh"
+
+install_go
+build_meta
+
+tools/meta/meta resolve-versions --mpd "${MPD_VERSION}" --libmpdclient "${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"

--- a/scripts/github/resolve-versions
+++ b/scripts/github/resolve-versions
@@ -4,7 +4,6 @@ set -euo pipefail
 
 . "scripts/github/common.sh"
 
-install_go
 build_meta
 
-tools/meta/meta resolve-versions --mpd "${MPD_VERSION}" --libmpdclient "${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"
+"${RUNNER_TEMP}/meta" resolve-versions --mpd "${MPD_VERSION}" --libmpdclient "${LIBMPDCLIENT_VERSION}" >> "${GITHUB_OUTPUT}"

--- a/scripts/run-integration
+++ b/scripts/run-integration
@@ -11,14 +11,22 @@ tagname="test/ashuffle:run_${run_id}"
 tty="-t"
 build_extra=()
 run_extra=()
+nobuild="false"
 
 while test $# -gt 0; do
     case "$1" in
         --no_tty)
             tty=""
             ;;
+        --no_build_use_image=*)
+            nobuild="true"
+            tagname="${1#"--no_build_use_image="}"
+            ;;
         --build.*)
             build_extra+=( "--${1#"--build."}" )
+            ;;
+        --build_bare.*)
+            build_extra+=( "${1#"--build_bare."}" )
             ;;
         *)
             run_extra+=( "$1" )
@@ -27,9 +35,11 @@ while test $# -gt 0; do
     shift
 done
 
-./scripts/build-test-image \
-    --image-tag "${tagname}" \
-    "${build_extra[@]}" || die "couldn't build test image"
+if [[ "${nobuild}" != "true" ]]; then
+    ./scripts/build-test-image \
+        --image-tag "${tagname}" \
+        "${build_extra[@]}" || die "couldn't build test image"
+fi
 
 exec docker run \
     --name "ashuffle_integration_run_${run_id}" \

--- a/t/docker/Dockerfile.ubuntu
+++ b/t/docker/Dockerfile.ubuntu
@@ -1,4 +1,35 @@
-FROM ghcr.io/joshkunz/ashuffle-integration-root:v2.6.0
+# Based on debian, so apt should work.
+FROM ubuntu:22.04
+
+# renovate: datasource=pypi depName=meson
+ENV MESON_VERSION=1.3.1
+
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update -y && \
+    env DEBIAN_FRONTEND=noninteraceive apt-get install --no-install-recommends -y \
+        build-essential \
+        cmake \
+        doxygen \
+        fuse \
+        gcc-9 g++-9 \
+        git \
+        libboost-all-dev \
+        libglib2.0-dev \
+        libmad0-dev libid3tag0-dev \
+        ninja-build \
+        pkg-config \
+        python3 python3-pip python3-setuptools python3-wheel \
+        valgrind \
+        wget \
+        xz-utils && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    pip3 install \
+        meson==${MESON_VERSION}
+
+COPY /t/docker/install_go.sh /opt/helpers/
+# renovate: datasource=github-tags depName=golang/go
+ENV GO_VERSION=go1.21.6
+RUN /opt/helpers/install_go.sh ${GO_VERSION}
 
 COPY /tools/meta/ /opt/meta
 RUN cd /opt/meta && go build

--- a/t/docker/Dockerfile.ubuntu
+++ b/t/docker/Dockerfile.ubuntu
@@ -1,5 +1,4 @@
-# Based on debian, so apt should work.
-FROM ubuntu:22.04
+FROM ubuntu:22.04 as build
 
 # renovate: datasource=pypi depName=meson
 ENV MESON_VERSION=1.3.1
@@ -27,6 +26,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update -y && \
         meson==${MESON_VERSION}
 
 COPY /t/docker/install_go.sh /opt/helpers/
+
 # renovate: datasource=github-tags depName=golang/go
 ENV GO_VERSION=go1.21.6
 RUN /opt/helpers/install_go.sh ${GO_VERSION}
@@ -54,19 +54,20 @@ RUN /opt/meta/meta install mpd \
 COPY /t/static/mpd.conf /conf
 
 # Copy in the integration test runner
-
 COPY /t/docker/run_integration.sh /exec/
 
-# The directory that contains the staged ashuffle source. If unset the
-# build directory (presumably the ashuffle root) is used. This has some
-# drawbacks, like potentially including a build directory that would conflict
-# with the container's build directory.
-ARG STAGE_DIR
-ENV STAGE_DIR ${STAGE_DIR:-./}
+# Copy in the sources for ashuffle and the tests.
 
-# This archive is created automatically by the build script. Note, this archive
-# is automatically extracted by this rule.
-ADD ${STAGE_DIR}/ashuffle-archive.tar /ashuffle/
+# subproject (dependency) sources
+COPY /subprojects/ /ashuffle/subprojects/
+# cmake helper to force absl to build in non-system mode
+COPY /tools/cmake/ /ashuffle/tools/cmake/
+# meson build scripts
+COPY meson* /ashuffle/
+# Actual sources
+COPY /src/ /ashuffle/src/
+# Integration tests
+COPY /t/integration/ /ashuffle/t/integration/
 
 RUN cd /ashuffle && \
     /opt/meta/meta testbuild

--- a/t/docker/install_go.sh
+++ b/t/docker/install_go.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+BINDIR=/usr/bin
+ROOT=/opt/go
+
+die() {
+    echo "$@" >&2
+    exit 1
+}
+
+mkdir -p "${ROOT}"
+test -d "${ROOT}" || die "build root '${ROOT}' not a valid directory"
+cd "${ROOT}"
+
+VERSION="$1"
+
+test -n "${VERSION}" || die "go version is empty, invalid version"
+
+url="https://go.dev/dl/${VERSION}.linux-amd64.tar.gz"
+wget -q -O- "${url}" | tar --strip-components=1 -xz
+if test "$?" -ne 0; then
+    die "couldn't download and extract ${VERSION} source"
+fi
+
+ln -s "${ROOT}/bin/go" "${BINDIR}/" || die "couldn't symlink go"
+ln -s "${ROOT}/bin/gofmt" "${BINDIR}/" || die "couldn't symlink gofmt"
+
+echo "Installed Go: $(go version)"
+exit 0

--- a/t/integration/go.mod
+++ b/t/integration/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fhs/gompd/v2 v2.3.0
 	github.com/google/go-cmp v0.6.0
-	github.com/joshkunz/fakelib v0.0.7
+	github.com/joshkunz/fakelib v0.0.8
 	github.com/joshkunz/massif v0.0.2
 	github.com/martinlindhe/unit v0.0.0-20230420213220-4adfd7d0a0d6
 	github.com/montanaflynn/stats v0.7.1
@@ -15,7 +15,7 @@ require (
 )
 
 require (
-	github.com/hanwen/go-fuse/v2 v2.4.0 // indirect
+	github.com/hanwen/go-fuse/v2 v2.4.2 // indirect
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 )

--- a/t/integration/go.sum
+++ b/t/integration/go.sum
@@ -9,10 +9,10 @@ github.com/fhs/gompd/v2 v2.3.0/go.mod h1:nNdZtcpD5VpmzZbRl5rV6RhxeMmAWTxEsSIMBkm
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hanwen/go-fuse/v2 v2.4.0 h1:12OhD7CkXXQdvxG2osIdBQLdXh+nmLXY9unkUIe/xaU=
-github.com/hanwen/go-fuse/v2 v2.4.0/go.mod h1:xKwi1cF7nXAOBCXujD5ie0ZKsxc8GGSA1rlMJc+8IJs=
-github.com/joshkunz/fakelib v0.0.7 h1:bp4WQLRD7Au5UemiOa32P1cSI8fTdvgJmblarnqWuAo=
-github.com/joshkunz/fakelib v0.0.7/go.mod h1:P1y/rltRgdMolHMCfa92NZvk8BXDvUlvZVIFzu5Fjdc=
+github.com/hanwen/go-fuse/v2 v2.4.2 h1:ujevavwvGMg4s1TTSGWqid0q7WHk0XC8EOzHtygnt9E=
+github.com/hanwen/go-fuse/v2 v2.4.2/go.mod h1:xKwi1cF7nXAOBCXujD5ie0ZKsxc8GGSA1rlMJc+8IJs=
+github.com/joshkunz/fakelib v0.0.8 h1:lG7XYuWMrO6424y+A2i5yfNFXD79RNUzx2TmeEgAPss=
+github.com/joshkunz/fakelib v0.0.8/go.mod h1:eTCUQIky5u4bwepQMOg4KJ8fstFDICSPz6YKAUTHbCI=
 github.com/joshkunz/massif v0.0.2 h1:eyFmmVDxMSIVBJ/OOHZaiTy1ofZqH1B4vs30N4a6ctE=
 github.com/joshkunz/massif v0.0.2/go.mod h1:KAmzsWWCPULX/NdP4qb5JYvjdDebq8+zE2oUwEajO0E=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=

--- a/tools/meta/commands/resolveversions/resolve_versions.go
+++ b/tools/meta/commands/resolveversions/resolve_versions.go
@@ -1,0 +1,61 @@
+package resolveversions
+
+import (
+	"fmt"
+	"meta/versions/libmpdclientver"
+	"meta/versions/mpdver"
+	"sort"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+func resolve(cliCtx *cli.Context) error {
+	var out []string
+
+	{
+		v, err := mpdver.Resolve(cliCtx.String("mpd"))
+		if err != nil {
+			return err
+		}
+		out = append(out, "MPD_VERSION="+v.String())
+	}
+
+	{
+		v, err := libmpdclientver.Resolve(cliCtx.String("libmpdclient"))
+		if err != nil {
+			return err
+		}
+		out = append(out, "LIBMPDCLIENT_VERSION="+v.String())
+	}
+
+	sort.Strings(out)
+	fmt.Println(strings.Join(out, "\n"))
+
+	return nil
+}
+
+var Command = &cli.Command{
+	Name:  "resolve-versions",
+	Usage: "resolve-versions --mpd latest --libmpdclient latest",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "mpd",
+			Value: "latest",
+			Usage: strings.Join([]string{
+				"version of mpd to resolve, or 'latest' to",
+				"automatically query for the latest released version, and",
+				"resolve that.",
+			}, " "),
+		},
+		&cli.StringFlag{
+			Name:  "libmpdclient",
+			Value: "latest",
+			Usage: strings.Join([]string{
+				"version of libmpdclient to resolve, or 'latest' to",
+				"automatically query for the latest released version.",
+			}, " "),
+		},
+	},
+	Action: resolve,
+}

--- a/tools/meta/meta.go
+++ b/tools/meta/meta.go
@@ -10,6 +10,7 @@ import (
 	"meta/commands/libmpdclient"
 	"meta/commands/mpd"
 	"meta/commands/release"
+	"meta/commands/resolveversions"
 	"meta/commands/testbuild"
 )
 
@@ -34,6 +35,7 @@ func main() {
 					mpd.Command,
 				},
 			},
+			resolveversions.Command,
 			release.Command,
 			testbuild.Command,
 		},

--- a/tools/meta/versions/libmpdclientver/libmpdclientver.go
+++ b/tools/meta/versions/libmpdclientver/libmpdclientver.go
@@ -1,0 +1,48 @@
+// Package libmpdclientver provides a version type for libmpdclient, and a
+// resolver for looking up the latest version.
+package libmpdclientver
+
+import (
+	"fmt"
+	"log"
+
+	"meta/fetch"
+	"meta/semver"
+)
+
+// GitURL is the URL of the libmpdclient git project.
+const GitURL = "https://github.com/MusicPlayerDaemon/libmpdclient.git"
+
+// Version is the type of a libmpdclient version.
+type Version semver.Version
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// ReleaseURL returns the release URL for this version of libmpdclient.
+func (v Version) ReleaseURL() string {
+	return fmt.Sprintf("https://www.musicpd.org/download/libmpdclient/%d/libmpdclient-%s.tar.xz", v.Major, v)
+}
+
+// Parse parses a given version string into a version.
+func Parse(v string) (Version, error) {
+	parsed, err := semver.Parse(v)
+	if err != nil {
+		return Version{}, err
+	}
+	return Version(parsed), nil
+}
+
+// Resolve either looks up, or parses the given version.
+func Resolve(v string) (Version, error) {
+	if v == "latest" {
+		log.Printf("version == latest, searching for latest version")
+		latest, err := fetch.GitLatest(GitURL)
+		if err != nil {
+			return Version{}, err
+		}
+		return Version(latest), err
+	}
+	return Parse(v)
+}

--- a/tools/meta/versions/mpdver/mpdver.go
+++ b/tools/meta/versions/mpdver/mpdver.go
@@ -1,0 +1,53 @@
+// Package mpdver provides version resolvers, and a version definition for
+// MPD.
+package mpdver
+
+import (
+	"fmt"
+	"log"
+
+	"meta/fetch"
+	"meta/semver"
+)
+
+// GitURL is the git repo URL for MPD
+const GitURL = "https://github.com/MusicPlayerDaemon/MPD.git"
+
+// Version is the type of an MPD version. It is based on semver with some
+// additional printing changes.
+type Version semver.Version
+
+func (v Version) String() string {
+	if v.Patch == 0 {
+		return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+	}
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// ReleaseURL is the release URL for this version.
+func (v Version) ReleaseURL() string {
+	return fmt.Sprintf("http://www.musicpd.org/download/mpd/%d.%d/mpd-%s.tar.xz", v.Major, v.Minor, v)
+}
+
+// Parse parses the given version.
+func Parse(s string) (Version, error) {
+	parsed, err := semver.Parse(s)
+	if err != nil {
+		return Version{}, err
+	}
+	return Version(parsed), nil
+}
+
+// Resolve resolves the latest version or parses the given given version.
+func Resolve(s string) (Version, error) {
+	if s == "latest" {
+		log.Printf("version == latest, looking up latest version")
+		latest, err := fetch.GitLatest(GitURL)
+		if err != nil {
+			return Version{}, err
+		}
+		return Version(latest), nil
+	}
+
+	return Parse(s)
+}


### PR DESCRIPTION
Goal here is twofold:

* Cache integration test containers across build jobs
* Eliminate the need for ashuffle-integration-root, so test environment/code changes can be landed at the same time.